### PR TITLE
Does not set the disabled attribute in widget

### DIFF
--- a/demo/tests/test_forms.py
+++ b/demo/tests/test_forms.py
@@ -226,6 +226,15 @@ class TestDynamicForm(TestCase):
         self.assertEquals(field.required, False)
         self.assertEquals(field.widget.attrs['disabled'], True)
 
+    def test_no_disabled_attr(self):
+        self.text_field.accesses.create(access_id=u'human', level=EDITABLE)
+        form_class = self.form.get_django_form_class(role=u'human')
+        form = form_class()
+        self.assertIn('text-input', form.fields)
+        field = form.fields['text-input']
+        self.assertEquals(field.required, False)
+        self.assertNotIn('disabled', field.widget.attrs)
+
     def test_hidden_field(self):
         self.text_field.accesses.create(access_id=u'human', level=HIDDEN)
         form_class = self.form.get_django_form_class(role=u'human')

--- a/formidable/forms/field_builder.py
+++ b/formidable/forms/field_builder.py
@@ -57,7 +57,12 @@ class FieldBuilder(object):
         return {'attrs': self.get_widget_attrs()}
 
     def get_widget_attrs(self):
-        return {'disabled': self.get_disabled()}
+        attrs = {}
+
+        if self.get_disabled():
+            attrs['disabled'] = True
+
+        return attrs
 
     def get_disabled(self):
         if self.access:


### PR DESCRIPTION
When a field is not disabled, the attribute `disabled` does not appear
in the input html balise. Whatever the value is, if the disabled
attribute appears, the field is automatically disabled.