### PR TITLE
Custom permissions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,17 @@ following line:
     url(r'^api/', include('formidable.urls', namespace='formidable'))
 
 
+By default, the views are not accessible, the permissions loaded are fully
+restrictive. To allow any access to the view fill your settings with
+
+.. code-block:: python
+
+    FORMIDABLE_DEFAULT_PERMISSION=['rest_framework.permissions.AllowAll']
+
+
+To handle special permissions, please refer to the online documentation.
+
+
 
 formidable-ui
 -------------

--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -88,6 +88,7 @@ DATABASES = {
 
 FORMIDABLE_ACCESS_RIGHTS_LOADER = 'demo.formidable_accesses.get_accesses'
 FORMIDABLE_CONTEXT_LOADER = 'demo.formidable_accesses.get_context'
+FORMIDABLE_PERMISSIONS_BUILDER = ['rest_framework.permissions.AllowAny']
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/

--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -88,7 +88,7 @@ DATABASES = {
 
 FORMIDABLE_ACCESS_RIGHTS_LOADER = 'demo.formidable_accesses.get_accesses'
 FORMIDABLE_CONTEXT_LOADER = 'demo.formidable_accesses.get_context'
-FORMIDABLE_PERMISSIONS_BUILDER = ['rest_framework.permissions.AllowAny']
+FORMIDABLE_DEFAULT_PERMISSION = ['rest_framework.permissions.AllowAny']
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/

--- a/demo/tests/test_permissions.py
+++ b/demo/tests/test_permissions.py
@@ -21,7 +21,7 @@ class TestMetaClassPermissions(TestCase):
         ]
     )
     def test_with_settings_key(self):
-        attrs = {'settings_permissions_key': 'FORMIDABLE_PERMISSION_BUILDER'}
+        attrs = {'settings_permission_key': 'FORMIDABLE_PERMISSION_BUILDER'}
         MyView = MetaClassView('MyView', (APIView,), attrs)
         permission_classes = MyView.permission_classes
         self.assertEqual(len(permission_classes), 1)
@@ -34,7 +34,7 @@ class TestMetaClassPermissions(TestCase):
         ]
     )
     def test_settings_key_not_define(self):
-        attrs = {'settings_permissions_key': 'FORMIDABLE_PERMISSION_BUILDER'}
+        attrs = {'settings_permission_key': 'FORMIDABLE_PERMISSION_BUILDER'}
         MyView = MetaClassView('MyView', (APIView,), attrs)
         permission_classes = MyView.permission_classes
         self.assertEqual(len(permission_classes), 1)
@@ -45,7 +45,7 @@ class TestMetaClassPermissions(TestCase):
         FORMIDABLE_DEFAULT_PERMISSION=None,
     )
     def test_no_settings_key_define(self):
-        attrs = {'settings_permissions_key': 'FORMIDABLE_PERMISSION_BUILDER'}
+        attrs = {'settings_permission_key': 'FORMIDABLE_PERMISSION_BUILDER'}
         MyView = MetaClassView('MyView', (APIView,), attrs)
         permission_classes = MyView.permission_classes
         self.assertEqual(len(permission_classes), 1)

--- a/demo/tests/test_permissions.py
+++ b/demo/tests/test_permissions.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from django.conf import settings
 from django.test import TestCase, override_settings
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.views import APIView
@@ -28,23 +29,22 @@ class TestMetaClassPermissions(TestCase):
         self.assertEqual(permission_classes[0], IsAuthenticated)
 
     @override_settings(
-        FORMIDABLE_PERMISSION_BUILDER=None,
         FORMIDABLE_DEFAULT_PERMISSION=[
             'rest_framework.permissions.AllowAny'
         ]
     )
     def test_settings_key_not_define(self):
+        del settings.FORMIDABLE_PERMISSION_BUILDER
+
         attrs = {'settings_permission_key': 'FORMIDABLE_PERMISSION_BUILDER'}
         MyView = MetaClassView('MyView', (APIView,), attrs)
         permission_classes = MyView.permission_classes
         self.assertEqual(len(permission_classes), 1)
         self.assertEqual(permission_classes[0], AllowAny)
 
-    @override_settings(
-        FORMIDABLE_PERMISSION_BUILDER=None,
-        FORMIDABLE_DEFAULT_PERMISSION=None,
-    )
     def test_no_settings_key_define(self):
+        del settings.FORMIDABLE_DEFAULT_PERMISSION
+
         attrs = {'settings_permission_key': 'FORMIDABLE_PERMISSION_BUILDER'}
         MyView = MetaClassView('MyView', (APIView,), attrs)
         permission_classes = MyView.permission_classes

--- a/demo/tests/test_permissions.py
+++ b/demo/tests/test_permissions.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+from django.test import TestCase, override_settings
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.views import APIView
+
+from formidable.views import FormidableDetail, MetaClassView
+from formidable.permissions import NoOne
+
+
+class TestMetaClassPermissions(TestCase):
+    """
+    We only test ``MetaClassView`` (which is responsible for permission
+    load) because permissions classes are generated while URL
+    configuration is loaded)
+
+    """
+
+    @override_settings(
+        FORMIDABLE_PERMISSION_BUILDER=[
+            'rest_framework.permissions.IsAuthenticated'
+        ]
+    )
+    def test_with_settings_key(self):
+        attrs = {'settings_permissions_key': 'FORMIDABLE_PERMISSION_BUILDER'}
+        MyView = MetaClassView('MyView', (APIView,), attrs)
+        permission_classes = MyView.permission_classes
+        self.assertEqual(len(permission_classes), 1)
+        self.assertEqual(permission_classes[0], IsAuthenticated)
+
+    @override_settings(
+        FORMIDABLE_PERMISSION_BUILDER=None,
+        FORMIDABLE_DEFAULT_PERMISSION=[
+            'rest_framework.permissions.AllowAny'
+        ]
+    )
+    def test_settings_key_not_define(self):
+        attrs = {'settings_permissions_key': 'FORMIDABLE_PERMISSION_BUILDER'}
+        MyView = MetaClassView('MyView', (APIView,), attrs)
+        permission_classes = MyView.permission_classes
+        self.assertEqual(len(permission_classes), 1)
+        self.assertEqual(permission_classes[0], AllowAny)
+
+    @override_settings(
+        FORMIDABLE_PERMISSION_BUILDER=None,
+        FORMIDABLE_DEFAULT_PERMISSION=None,
+    )
+    def test_no_settings_key_define(self):
+        attrs = {'settings_permissions_key': 'FORMIDABLE_PERMISSION_BUILDER'}
+        MyView = MetaClassView('MyView', (APIView,), attrs)
+        permission_classes = MyView.permission_classes
+        self.assertEqual(len(permission_classes), 1)
+        self.assertEqual(permission_classes[0], NoOne)
+
+
+class TestPermission(TestCase):
+
+    def test_permissions_builder_loading(self):
+        self.assertTrue(hasattr(FormidableDetail, 'permission_classes'))
+        permission_classes = FormidableDetail.permission_classes
+        self.assertEqual(len(permission_classes), 1)
+        self.assertEqual(permission_classes[0], AllowAny)

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -104,3 +104,33 @@ following line:
 .. code-block:: python
 
     url(r'^api/', include('formidable.urls', namespace='formidable'))
+
+
+URLs accesses
+-------------
+
+The ``Formidable`` views are built with ``djangorestframework`` and use the
+related permissions in order to handle accesses. So, you can write your
+own permissions with ``djangorestframework`` and use it in ``django-formidable``
+views.
+
+
+By default, a restrictive permission is applied on all API views if nothing is
+specified in django settings.
+
+You can specified a list of permissions classes to all the API views by
+providing the configuration key ``FORMIDABLE_DEFAULT_PERMISSION``
+
+.. code-block:: python
+
+    FORMIDABLE_DEFAULT_PERMISSION = ['rest_framework.permissions.AllowAll']
+
+
+There are two kinds of views,
+
+1. views which allow to create or edit forms (handled
+by ``FORMIDABLE_PERMISSION_BUILDER``)
+2. views to use the form previously defined (handled by.
+``FORMIDABLE_PERMISSION_USING``).
+
+You can provide any permissions you want.

--- a/formidable/permissions.py
+++ b/formidable/permissions.py
@@ -1,0 +1,7 @@
+from rest_framework.permissions import BasePermission
+
+
+class NoOne(BasePermission):
+
+    def has_permission(self, *args, **kwargs):
+        return False

--- a/formidable/views.py
+++ b/formidable/views.py
@@ -37,8 +37,6 @@ class MetaClassView(type):
 
     def __new__(mcls, name, bases, attrs):
 
-        # Try to get the settings key to load, if the settings key is not
-        # define, load the FORMIDABLE_DEFAULT_PERMISSION settings.
         settings_key = attrs.get(
             'settings_permission_key', 'FORMIDABLE_DEFAULT_PERMISSION'
         )

--- a/formidable/views.py
+++ b/formidable/views.py
@@ -41,14 +41,11 @@ class MetaClassView(type):
             'settings_permission_key', 'FORMIDABLE_DEFAULT_PERMISSION'
         )
 
-        # if the settings key define is not presents in the settings
-        # The NoOne permission is loaded.
-        modules = getattr(settings, settings_key, None)
-        if not modules:
-            modules = getattr(settings, 'FORMIDABLE_DEFAULT_PERMISSION', None)
-            # Not define or falsy value
-            if not modules:
-                modules = ['formidable.permissions.NoOne']
+        # If the settings key define is not present in the settings
+        # The ``NoOne`` permission is loaded.
+        modules = getattr(settings, settings_key,
+                  getattr(settings, 'FORMIDABLE_DEFAULT_PERMISSION',  # noqa
+                  ['formidable.permissions.NoOne']))                  # noqa
 
         permissions_classes = perform_import(modules, None)
         attrs['permission_classes'] = permissions_classes

--- a/formidable/views.py
+++ b/formidable/views.py
@@ -1,19 +1,17 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import six
-
-
-from django.db.models import Prefetch
 from django.conf import settings
+from django.db.models import Prefetch
 
+import six
 from rest_framework import exceptions
 from rest_framework.generics import (
     CreateAPIView, RetrieveAPIView, RetrieveUpdateAPIView
 )
 from rest_framework.response import Response
-from rest_framework.views import APIView
 from rest_framework.settings import perform_import
+from rest_framework.views import APIView
 
 from formidable.accesses import get_accesses, get_context
 from formidable.forms.validations.presets import presets_register

--- a/formidable/views.py
+++ b/formidable/views.py
@@ -41,13 +41,15 @@ class MetaClassView(type):
 
         # Try to get the settings key to load, if the settings key is not
         # define, load the FORMIDABLE_DEFAULT_PERMISSION settings.
-        settings_key = attrs['settings_permissions_key']
+        settings_key = attrs.get(
+            'settings_permission_key', 'FORMIDABLE_DEFAULT_PERMISSION'
+        )
 
         # if the settings key define is not presents in the settings
         # The NoOne permission is loaded.
         modules = getattr(settings, settings_key, None)
         if not modules:
-            modules = getattr(settings, 'FORMIDABLE_DEFAULT_PERMISSION')
+            modules = getattr(settings, 'FORMIDABLE_DEFAULT_PERMISSION', None)
             # Not define or falsy value
             if not modules:
                 modules = ['formidable.permissions.NoOne']
@@ -62,7 +64,7 @@ class FormidableDetail(six.with_metaclass(MetaClassView,
 
     queryset = Formidable.objects.all()
     serializer_class = FormidableSerializer
-    settings_permissions_key = 'FORMIDABLE_PERMISSIONS_BUILDER'
+    settings_permission_key = 'FORMIDABLE_PERMISSION_BUILDER'
 
     def get_queryset(self):
         qs = super(FormidableDetail, self).get_queryset()
@@ -70,15 +72,17 @@ class FormidableDetail(six.with_metaclass(MetaClassView,
         return qs.prefetch_related(Prefetch('fields', queryset=field_qs))
 
 
-class FormidableCreate(CreateAPIView):
+class FormidableCreate(six.with_metaclass(MetaClassView, CreateAPIView)):
     queryset = Formidable.objects.all()
     serializer_class = FormidableSerializer
+    settings_permission_key = 'FORMIDABLE_PERMISSION_BUILDER'
 
 
-class ContextFormDetail(RetrieveAPIView):
+class ContextFormDetail(six.with_metaclass(MetaClassView, RetrieveAPIView)):
 
     queryset = Formidable.objects.all()
     serializer_class = ContextFormSerializer
+    settings_permission_key = 'FORMIDABLE_PERMISSION_USING'
 
     def get_queryset(self):
         qs = super(ContextFormDetail, self).get_queryset()
@@ -91,7 +95,9 @@ class ContextFormDetail(RetrieveAPIView):
         return context
 
 
-class AccessList(APIView):
+class AccessList(six.with_metaclass(MetaClassView, APIView)):
+
+    settings_permission_key = 'FORMIDABLE_PERMISSION_BUILDER'
 
     def get(self, request, format=None):
         serializer = SimpleAccessSerializer(data=get_accesses())
@@ -101,7 +107,9 @@ class AccessList(APIView):
             return Response(data=serializer.errors, status_code=400)
 
 
-class PresetsList(APIView):
+class PresetsList(six.with_metaclass(MetaClassView, APIView)):
+
+    settings_permission_key = 'FORMIDABLE_PERMISSION_BUILDER'
 
     def get(self, request, format=None):
         presets_declarations = [
@@ -114,7 +122,9 @@ class PresetsList(APIView):
         return Response(serializer.data)
 
 
-class ValidateView(APIView):
+class ValidateView(six.with_metaclass(MetaClassView, APIView)):
+
+    settings_permission_key = 'FORMIDABLE_PERMISSION_USING'
 
     def get(self, request, **kwargs):
         try:


### PR DESCRIPTION
Added a hook in order to plug custom permissions on each view provided by Formidable.

The permissions classes can be added through settings with a pyramidal policy

- If no settings key is provided, the NoOne permission is apply
- If the global FORMIDABLE_DEFAULT_PERMISSION is provided, these classes are applied
- If the specific key (depending the view) is specified, the permissions classes are applied.