### PR TITLE
Add email field

### DIFF
--- a/demo/tests/test_end_point.py
+++ b/demo/tests/test_end_point.py
@@ -171,6 +171,18 @@ class RenderSerializerTestCase(TestCase):
                          'This is on onboarding form.')
         self.assertNotIn('help_text', data)
 
+    def test_email_field(self):
+        self.form.fields.all().delete()
+        self.email = self.form.fields.create(
+            type_id='email', slug='email',
+            label='Your email',
+            order=self.form.get_next_field_order()
+        )
+        serializer = FormidableSerializer(instance=self.form)
+        data = serializer.data['fields'][0]
+        for field in RENDER_BASE_FIELDS:
+            self.assertIn(field, data)
+
     def test_separator_field(self):
         self.form.fields.all().delete()
         self.sepa = self.form.fields.create(

--- a/demo/tests/test_forms.py
+++ b/demo/tests/test_forms.py
@@ -130,6 +130,17 @@ class TestDynamicForm(TestCase):
         self.assertTrue(dropdown.choices)
         self.assertEquals(len(dropdown.choices), 2)
 
+    def test_email_input(self):
+        self.form.fields.create(
+            slug='email', type_id='email', label='my email',
+            order=self.form.get_next_field_order()
+        )
+        form_class = self.form.get_django_form_class()
+        form = form_class()
+        self.assertIn('email', form.fields)
+        email = form.fields['email']
+        self.assertEqual(type(email), forms.EmailField)
+
     def test_dropdown_input_multiple(self):
         drop = self.form.fields.create(
             slug=u'multiple-weapons', type_id=u'dropdown',

--- a/demo/tests/test_from_form.py
+++ b/demo/tests/test_from_form.py
@@ -343,6 +343,21 @@ class TestFromDjangoForm(TestCase):
             slug='checkboxinput', type_id='checkbox', label='Do you agree ?'
         ).exists())
 
+    def test_email_field(self):
+
+        class MyForm(FormidableForm):
+
+            email = fields.EmailField(label='Your email')
+
+        initial_count = Formidable.objects.count()
+        form = MyForm.to_formidable(label='form-with-email')
+        self.assertEquals(initial_count + 1, Formidable.objects.count())
+        self.assertTrue(form.pk)
+        self.assertEquals(form.fields.count(), 1)
+        self.assertTrue(form.fields.filter(
+            slug='email', type_id='email', label='Your email',
+        ).exists())
+
     def test_checkbox_multiple_field(self):
 
         choices = (

--- a/formidable/forms/fields.py
+++ b/formidable/forms/fields.py
@@ -200,6 +200,11 @@ class IntegerField(Field, fields.IntegerField):
     widget = widgets.NumberInput
 
 
+class EmailField(Field, fields.EmailField):
+
+    widget = widgets.EmailInput
+
+
 class ItemField(Field):
 
     def __init__(self, defaults=None, *args, **kwargs):

--- a/formidable/forms/widgets.py
+++ b/formidable/forms/widgets.py
@@ -136,6 +136,11 @@ class NumberInput(FormidableWidget, widgets.NumberInput):
     type_id = u'number'
 
 
+class EmailInput(FormidableWidget, widgets.EmailInput):
+
+    type_id = 'email'
+
+
 class ClearableFileInput(FormidableWidget, widgets.ClearableFileInput):
 
     type_id = u'file'


### PR DESCRIPTION
Email Field was already handle by serializer on creation, edition and contextualized rendering. 

Only the case in python builder was missing, the PR added it and few tests about above case.