### PR TITLE
Add a method in order to get the formidable object

### DIFF
--- a/formidable/views.py
+++ b/formidable/views.py
@@ -120,9 +120,12 @@ class ValidateView(six.with_metaclass(MetaClassView, APIView)):
 
     settings_permission_key = 'FORMIDABLE_PERMISSION_USING'
 
+    def get_formidable_object(self, kwargs):
+        return Formidable.objects.get(pk=kwargs['pk'])
+
     def get(self, request, **kwargs):
         try:
-            formidable = Formidable.objects.get(pk=kwargs['pk'])
+            formidable = self.get_formidable_object(kwargs)
         except Formidable.DoesNotExist:
             raise exceptions.Http404()
 


### PR DESCRIPTION
In ValdiationView, the method to get the formidable object was "static".
Just check the "pk" key in the kwargs dict of the view. But, if the
client need another method to fetche the formidable object, no way was
offer. The main idea is to provide a method overridable in order to have
customisable point for the client.