### PR TITLE
[models] Add static method to create an instance from JSON

### DIFF
--- a/formidable/models.py
+++ b/formidable/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+from django.core.exceptions import ValidationError
 from django.db import models
 
 from formidable import constants
@@ -31,6 +32,26 @@ class Formidable(models.Model):
         """
         agg = self.fields.aggregate(models.Max('order'))
         return agg['order__max'] + 1 if agg['order__max'] is not None else 0
+
+    @staticmethod
+    def from_json(definition_schema, **kwargs):
+        """
+        Proxy static method to create an instance of ``Formidable`` more
+        easily with a given ``definition_schema``.
+
+        :params definition_schema: Schema in JSON/dict
+
+        >>> Formidable.from_json(definition_schema)
+        <Formidable: Formidable object>
+
+        """
+        from formidable.serializers import FormidableSerializer
+
+        serializer = FormidableSerializer(data=definition_schema)
+        if serializer.is_valid():
+            return serializer.save(**kwargs)
+
+        raise ValidationError(serializer.errors)
 
 
 class Field(models.Model):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
 
 setup(
     name='django-formidable',
-    version='0.4.0dev',
+    version='0.4.0.dev0',
     packages=find_packages(),
     include_package_data=True,
     license='BSD License',


### PR DESCRIPTION
I added a proxy static method to create an instance of `Formidable` more easily from a JSON definition:

```python
>>> form = Formidable.from_json(schema_definition)
```

This implements an alternative constructor, using `FormidableSerializer`.
I also added some tests against valid/invalid JSON schema.

_This is just a suggestion @moumoutte · Feel free to reject the PR!_ :wink: 