### PR TITLE
Fix warnings caused by autodoc when building Sphinx documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Release 0.4.0dev (unreleased)
 * A few typo fixes in documentation (#128).
 * Added a Makefile autodocumentation (#127).
 * Added a tox target to build documentation (#130).
+* Fix autodoc generation (#131).
 
 Release 0.3.1 (2016-11-04)
 ==========================

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -55,7 +55,7 @@ clean:
 
 .PHONY: html
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	PYTHONPATH='..' DJANGO_SETTINGS_MODULE='demo.settings' $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,14 +14,19 @@
 
 import sys
 import os
+from django.conf import settings
+import django
+
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(0, os.path.abspath('..'))
-from django.conf import settings
 settings.configure()
+# Setting up the django apps
+django.setup()
+
 
 # -- General configuration ------------------------------------------------
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,9 +21,11 @@ commands =
 
 [testenv:docs]
 deps =
+    ; doc building is using the latest LTS version to date (december 2016)
+    Django>=1.8,<1.9
     Sphinx
 whitelist_externals =
     make
 changedir = docs
 commands =
-    make html
+    make clean html


### PR DESCRIPTION
closes #131


### Before

```
$ rm docs/build/ -Rf && tox -re docs

GLOB sdist-make: /home/novapost/Projets/PeopleAsk/django-formidable/setup.py

[SNIP... SNIP... SNIP...]

/home/novapost/Projets/PeopleAsk/django-formidable/docs/source/forms.rst:14: WARNING: autodoc: failed to import class u'Formidable' from module u'formidable.models'; the following exception was raised:
Traceback (most recent call last):

[SNIP... SNIP... SNIP...]

AppRegistryNotReady: Apps aren't loaded yet.
/home/novapost/Projets/PeopleAsk/django-formidable/docs/source/forms.rst:275: WARNING: autodoc: failed to import module u'formidable.forms.fields'; the following exception was raised:

[SNIP... SNIP... SNIP...]

build succeeded, 3 warnings.

Build finished. The HTML pages are in build/html.
summary
  docs: commands succeeded
  congratulations :)
```

The keyword here is: "**3 WARNINGS**"

### After

```
$ rm docs/build/ -Rf && tox -re docs

[SNIP... SNIP... SNIP...]

updating environment: 4 added, 0 changed, 0 removed
reading sources... [ 25%] forms
reading sources... [ 50%] index
reading sources... [ 75%] install
reading sources... [100%] intro

looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [ 25%] forms
writing output... [ 50%] index
writing output... [ 75%] install
writing output... [100%] intro

generating indices... genindex py-modindex
writing additional pages... search
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded.

Build finished. The HTML pages are in build/html.
summary
  docs: commands succeeded
  congratulations :)
```

No warning, no error, everything is fine fine fine.