### PR TITLE
Added a callback mechanism when creating / updating a form via the builder

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Release 0.5.0dev (unreleased)
 =============================
 
 * Fix the demo site to work with Django 1.8 *and* with logged-in users (#146).
+* Added a callback on success / failure mechanism (#134).
 
 
 Release 0.4.0 (2017-04-01)

--- a/demo/demo/__init__.py
+++ b/demo/demo/__init__.py
@@ -1,3 +1,8 @@
+import logging
+
+
+logger = logging.getLogger(__name__)
+
 
 class DemoCallbackException(Exception):
     "A dummy callback exception"
@@ -19,3 +24,23 @@ def callback_exception(*args, **kwargs):
     It'll raise an exception
     """
     raise DemoCallbackException()
+
+
+def callback_success_message(request):
+    """
+    This function will be called a form post-save/create.
+
+    It adds a logging message
+    """
+    logger.info('Sucessfully recorded form :)')
+    return True
+
+
+def callback_fail_message(request):
+    """
+    This function will be called a form post-save/create.
+
+    It adds a logging message (error)
+    """
+    logger.error('Form storing has failed :(')
+    return True

--- a/demo/demo/__init__.py
+++ b/demo/demo/__init__.py
@@ -1,0 +1,7 @@
+def callback_save(*args, **kwargs):
+    """
+    This function will be called as a dummy callback on form post-save/create.
+
+    It doesn't do much, and that's fine.
+    """
+    return True

--- a/demo/demo/__init__.py
+++ b/demo/demo/__init__.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.contrib import messages
 
 logger = logging.getLogger(__name__)
 
@@ -31,9 +32,11 @@ def callback_success_message(request):
     This function will be called a form post-save/create.
 
     It adds a logging message
+
     """
-    logger.info('Sucessfully recorded form :)')
-    return True
+    msg = 'Sucessfully recorded form :)'
+    logger.info(msg)
+    messages.info(request._request, msg)
 
 
 def callback_fail_message(request):
@@ -42,5 +45,6 @@ def callback_fail_message(request):
 
     It adds a logging message (error)
     """
-    logger.error('Form storing has failed :(')
-    return True
+    msg = 'Form storing has failed :('
+    logger.error(msg)
+    messages.error(request._request, msg)

--- a/demo/demo/__init__.py
+++ b/demo/demo/__init__.py
@@ -1,3 +1,8 @@
+
+class DemoCallbackException(Exception):
+    "A dummy callback exception"
+
+
 def callback_save(*args, **kwargs):
     """
     This function will be called as a dummy callback on form post-save/create.
@@ -5,3 +10,12 @@ def callback_save(*args, **kwargs):
     It doesn't do much, and that's fine.
     """
     return True
+
+
+def callback_exception(*args, **kwargs):
+    """
+    This function will be called-back on form post-save/create
+
+    It'll raise an exception
+    """
+    raise DemoCallbackException()

--- a/demo/demo/builder/templates/formidable/formidable_list.html
+++ b/demo/demo/builder/templates/formidable/formidable_list.html
@@ -4,6 +4,15 @@
 <div class="title">
   <h1>May the Form be with you!</h1>
 </div>
+
+{% if messages %}
+<ul class="messages">
+    {% for message in messages %}
+    <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+    {% endfor %}
+</ul>
+{% endif %}
+
 <div>
   <table>
     <thead>

--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -115,3 +115,10 @@ STATICFILES_DIRS = [
 ]
 
 CORS_ORIGIN_ALLOW_ALL = True
+
+
+# Formidable call back post-create/update
+FORMIDABLE_POST_CREATE_CALLBACK_SUCCESS = 'demo.callback_success_message'
+FORMIDABLE_POST_UPDATE_CALLBACK_SUCCESS = 'demo.callback_success_message'
+FORMIDABLE_POST_CREATE_CALLBACK_FAIL = 'demo.callback_fail_message'
+FORMIDABLE_POST_UPDATE_CALLBACK_FAIL = 'demo.callback_fail_message'

--- a/demo/requirements-demo.pip
+++ b/demo/requirements-demo.pip
@@ -2,4 +2,3 @@ django-cors-headers
 ipdb
 django-extensions
 freezegun
-mock

--- a/demo/requirements-demo.pip
+++ b/demo/requirements-demo.pip
@@ -2,3 +2,4 @@ django-cors-headers
 ipdb
 django-extensions
 freezegun
+mock

--- a/demo/tests/__init__.py
+++ b/demo/tests/__init__.py
@@ -1,0 +1,45 @@
+
+form_data = {
+    "label": "test create",
+    "description": "my first formidable by api",
+    "fields": [
+        {
+            "label": "hello",
+            "slug": "textslug",
+            "type_id": "text",
+            "placeholder": None,
+            "help_text": None,
+            "default": None,
+            "accesses": [
+                {"access_id": "padawan", "level": "REQUIRED"},
+                {"access_id": "jedi", "level": "EDITABLE"},
+                {"access_id": "jedi-master", "level": "READONLY"},
+                {"access_id": "human", "level": "HIDDEN"},
+            ]
+        },
+    ]
+}
+
+form_data_items = {
+    "label": "test create",
+    "description": "my first formidable by api",
+    "fields": [{
+        "label": "my_dropdwon",
+        "slug": "dropdown_slug",
+        "type_id": "dropdown",
+        "placeholder": None,
+        "help_text": "Lesfrites c'est bon",
+        "default": None,
+        "accesses": [
+            {"access_id": "padawan", "level": "REQUIRED"},
+            {"access_id": "jedi", "level": "EDITABLE"},
+            {"access_id": "jedi-master", "level": "READONLY"},
+            {"access_id": "human", "level": "HIDDEN"},
+        ],
+        "items": [
+            {'value': 'tuto', 'label': 'toto'},
+            {'value': 'plop', 'label': 'coin'},
+        ],
+        "multiple": False
+    }]
+}

--- a/demo/tests/test_post_save_callbacks.py
+++ b/demo/tests/test_post_save_callbacks.py
@@ -15,6 +15,7 @@ else:
     from mock import patch
 
 CALLBACK = 'demo.callback_save'
+CALLBACK_EXCEPTION = 'demo.callback_exception'
 
 
 class CreateFormTestCase(APITestCase):
@@ -53,3 +54,27 @@ class CreateFormTestCase(APITestCase):
             )
             self.assertEquals(res.status_code, 400)
             self.assertEqual(patched_callback.call_count, 1)
+
+    @override_settings(
+        FORMIDABLE_POST_CREATE_CALLBACK_SUCCESS=CALLBACK_EXCEPTION
+    )
+    def test_create_exception(self):
+        # The called function raises an error, but the treatment proceeds
+        # as if nothing has happened
+        res = self.client.post(
+            reverse('formidable:form_create'), form_data, format='json'
+        )
+        self.assertEqual(res.status_code, 201)
+
+    @override_settings(
+        FORMIDABLE_POST_CREATE_CALLBACK_SUCCESS=CALLBACK_EXCEPTION
+    )
+    def test_create_exception_logger(self):
+        # The called function raises an error, but the treatment proceeds
+        # as if nothing has happened
+        with patch('formidable.views.logger.error') as logger_error:
+            res = self.client.post(
+                reverse('formidable:form_create'), form_data, format='json'
+            )
+            self.assertEqual(res.status_code, 201)
+            self.assertEqual(logger_error.call_count, 1)

--- a/demo/tests/test_post_save_callbacks.py
+++ b/demo/tests/test_post_save_callbacks.py
@@ -78,3 +78,13 @@ class CreateFormTestCase(APITestCase):
             )
             self.assertEqual(res.status_code, 201)
             self.assertEqual(logger_error.call_count, 1)
+
+    @override_settings(FORMIDABLE_POST_CREATE_CALLBACK_SUCCESS='non.existent')
+    def test_create_callback_is_non_existent(self):
+        # A non-existing module is treated separately.
+        with patch('formidable.views.logger.error') as logger_error:
+            res = self.client.post(
+                reverse('formidable:form_create'), form_data, format='json'
+            )
+            self.assertEqual(res.status_code, 201)
+            self.assertEqual(logger_error.call_count, 1)

--- a/demo/tests/test_post_save_callbacks.py
+++ b/demo/tests/test_post_save_callbacks.py
@@ -6,6 +6,9 @@ from django.core.urlresolvers import reverse
 from django.test import override_settings
 
 from rest_framework.test import APITestCase
+
+from formidable.models import Formidable
+
 from . import form_data, form_data_items
 
 import six
@@ -87,4 +90,86 @@ class CreateFormTestCase(APITestCase):
                 reverse('formidable:form_create'), form_data, format='json'
             )
             self.assertEqual(res.status_code, 201)
+            self.assertEqual(logger_error.call_count, 1)
+
+
+class UpdateFormTestCase(APITestCase):
+
+    def setUp(self):
+        super(UpdateFormTestCase, self).setUp()
+        self.form = Formidable.objects.create(
+            label='test', description='test'
+        )
+
+    @override_settings(
+        FORMIDABLE_POST_UPDATE_CALLBACK_SUCCESS=CALLBACK,
+        FORMIDABLE_POST_UPDATE_CALLBACK_FAIL=CALLBACK
+    )
+    def test_do_no_call_on_get(self):
+        with patch(CALLBACK) as patched_callback:
+            res = self.client.get(
+                reverse('formidable:form_detail', args=[self.form.id])
+            )
+            self.assertEqual(res.status_code, 200)
+            # No call on GET
+            self.assertEqual(patched_callback.call_count, 0)
+
+    @override_settings(FORMIDABLE_POST_UPDATE_CALLBACK_SUCCESS=CALLBACK)
+    def test_update_no_error_post(self):
+        with patch(CALLBACK) as patched_callback:
+            res = self.client.put(
+                reverse('formidable:form_detail', args=[self.form.id]),
+                form_data, format='json'
+            )
+            self.assertEqual(res.status_code, 200)
+            self.assertEqual(patched_callback.call_count, 1)
+
+    @override_settings(FORMIDABLE_POST_UPDATE_CALLBACK_FAIL=CALLBACK)
+    def test_update_error_post(self):
+        with patch(CALLBACK) as patched_callback:
+            form_data_without_items = deepcopy(form_data_items)
+            form_data_without_items['fields'][0].pop('items')
+
+            res = self.client.put(
+                reverse('formidable:form_detail', args=[self.form.id]),
+                form_data_without_items, format='json'
+            )
+            self.assertEquals(res.status_code, 400)
+            self.assertEqual(patched_callback.call_count, 1)
+
+    @override_settings(
+        FORMIDABLE_POST_UPDATE_CALLBACK_SUCCESS=CALLBACK_EXCEPTION
+    )
+    def test_update_exception(self):
+        # The called function raises an error, but the treatment proceeds
+        # as if nothing has happened
+        res = self.client.put(
+            reverse('formidable:form_detail', args=[self.form.id]),
+            form_data, format='json'
+        )
+        self.assertEqual(res.status_code, 200)
+
+    @override_settings(
+        FORMIDABLE_POST_UPDATE_CALLBACK_SUCCESS=CALLBACK_EXCEPTION
+    )
+    def test_update_exception_logger(self):
+        # The called function raises an error, but the treatment proceeds
+        # as if nothing has happened
+        with patch('formidable.views.logger.error') as logger_error:
+            res = self.client.put(
+                reverse('formidable:form_detail', args=[self.form.id]),
+                form_data, format='json'
+            )
+            self.assertEqual(res.status_code, 200)
+            self.assertEqual(logger_error.call_count, 1)
+
+    @override_settings(FORMIDABLE_POST_UPDATE_CALLBACK_SUCCESS='non.existent')
+    def test_update_callback_is_non_existent(self):
+        # A non-existing module is treated separately.
+        with patch('formidable.views.logger.error') as logger_error:
+            res = self.client.put(
+                reverse('formidable:form_detail', args=[self.form.id]),
+                form_data, format='json'
+            )
+            self.assertEqual(res.status_code, 200)
             self.assertEqual(logger_error.call_count, 1)

--- a/demo/tests/test_post_save_callbacks.py
+++ b/demo/tests/test_post_save_callbacks.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from copy import deepcopy
+from mock import patch
+
+from django.core.urlresolvers import reverse
+from django.test import override_settings
+
+from rest_framework.test import APITestCase
+from . import form_data, form_data_items
+
+CALLBACK = 'demo.callback_save'
+
+
+class CreateFormTestCase(APITestCase):
+
+    @override_settings(FORMIDABLE_POST_CREATE_CALLBACK_SUCCESS=CALLBACK)
+    def test_create_no_error(self):
+        with patch(CALLBACK) as patched_callback:
+            res = self.client.post(
+                reverse('formidable:form_create'), form_data, format='json'
+            )
+            self.assertEqual(res.status_code, 201)
+            self.assertEqual(patched_callback.call_count, 1)
+
+    @override_settings(FORMIDABLE_POST_CREATE_CALLBACK_FAIL='demo.callback_save')
+    def test_create_error(self):
+        with patch(CALLBACK) as patched_callback:
+            form_data_without_items = deepcopy(form_data_items)
+            form_data_without_items['fields'][0].pop('items')
+
+            res = self.client.post(
+                reverse('formidable:form_create'), form_data_without_items,
+                format='json'
+            )
+            self.assertEquals(res.status_code, 400)
+            self.assertEqual(patched_callback.call_count, 1)

--- a/demo/tests/test_post_save_callbacks.py
+++ b/demo/tests/test_post_save_callbacks.py
@@ -2,13 +2,17 @@
 from __future__ import unicode_literals
 
 from copy import deepcopy
-from mock import patch
-
 from django.core.urlresolvers import reverse
 from django.test import override_settings
 
 from rest_framework.test import APITestCase
 from . import form_data, form_data_items
+
+import six
+if six.PY3:
+    from unittest.mock import patch
+else:
+    from mock import patch
 
 CALLBACK = 'demo.callback_save'
 

--- a/demo/tests/test_post_save_callbacks_regression_tests.py
+++ b/demo/tests/test_post_save_callbacks_regression_tests.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from copy import deepcopy
+
+from django.core.urlresolvers import reverse
+from django.test import override_settings
+from django.conf import settings
+
+from rest_framework.test import APITestCase
+from . import form_data, form_data_items
+
+
+class CreateFormTestCase(APITestCase):
+
+    @override_settings(FORMIDABLE_POST_CREATE_CALLBACK_SUCCESS=None)
+    def test_create_no_error(self):
+        res = self.client.post(
+            reverse('formidable:form_create'), form_data, format='json'
+        )
+        self.assertEquals(res.status_code, 201)
+
+    @override_settings(FORMIDABLE_POST_CREATE_CALLBACK_FAIL=None)
+    def test_create_error(self):
+        form_data_without_items = deepcopy(form_data_items)
+        form_data_without_items['fields'][0].pop('items')
+
+        res = self.client.post(
+            reverse('formidable:form_create'), form_data_without_items,
+            format='json'
+        )
+        self.assertEquals(res.status_code, 400)
+
+    @override_settings()
+    def test_create_no_settings_no_error(self):
+        del settings.FORMIDABLE_POST_CREATE_CALLBACK_SUCCESS
+        res = self.client.post(
+            reverse('formidable:form_create'), form_data, format='json'
+        )
+        self.assertEquals(res.status_code, 201)
+
+    @override_settings()
+    def test_create_no_settings_error(self):
+        del settings.FORMIDABLE_POST_CREATE_CALLBACK_FAIL
+        form_data_without_items = deepcopy(form_data_items)
+        form_data_without_items['fields'][0].pop('items')
+
+        res = self.client.post(
+            reverse('formidable:form_create'), form_data_without_items,
+            format='json'
+        )
+        self.assertEquals(res.status_code, 400)

--- a/demo/tests/test_post_save_callbacks_regression_tests.py
+++ b/demo/tests/test_post_save_callbacks_regression_tests.py
@@ -8,6 +8,9 @@ from django.test import override_settings
 from django.conf import settings
 
 from rest_framework.test import APITestCase
+
+from formidable.models import Formidable
+
 from . import form_data, form_data_items
 
 
@@ -48,5 +51,54 @@ class CreateFormTestCase(APITestCase):
         res = self.client.post(
             reverse('formidable:form_create'), form_data_without_items,
             format='json'
+        )
+        self.assertEquals(res.status_code, 400)
+
+
+class UpdateFormTestCase(APITestCase):
+
+    def setUp(self):
+        super(UpdateFormTestCase, self).setUp()
+        self.form = Formidable.objects.create(
+            label='test', description='test'
+        )
+
+    @override_settings(FORMIDABLE_POST_UPDATE_CALLBACK_SUCCESS=None)
+    def test_update_no_error(self):
+        res = self.client.put(
+            reverse('formidable:form_detail', args=[self.form.id]),
+            form_data, format='json'
+        )
+        self.assertEquals(res.status_code, 200)
+
+    @override_settings(FORMIDABLE_POST_UPDATE_CALLBACK_FAIL=None)
+    def test_update_error(self):
+        form_data_without_items = deepcopy(form_data_items)
+        form_data_without_items['fields'][0].pop('items')
+
+        res = self.client.put(
+            reverse('formidable:form_detail', args=[self.form.id]),
+            form_data_without_items, format='json'
+        )
+        self.assertEquals(res.status_code, 400)
+
+    @override_settings()
+    def test_update_no_settings_no_error(self):
+        del settings.FORMIDABLE_POST_UPDATE_CALLBACK_SUCCESS
+        res = self.client.put(
+            reverse('formidable:form_detail', args=[self.form.id]),
+            form_data, format='json'
+        )
+        self.assertEquals(res.status_code, 200)
+
+    @override_settings()
+    def test_update_no_settings_error(self):
+        del settings.FORMIDABLE_POST_UPDATE_CALLBACK_FAIL
+        form_data_without_items = deepcopy(form_data_items)
+        form_data_without_items['fields'][0].pop('items')
+
+        res = self.client.put(
+            reverse('formidable:form_detail', args=[self.form.id]),
+            form_data_without_items, format='json'
         )
         self.assertEquals(res.status_code, 400)

--- a/demo/tests/tests_integration.py
+++ b/demo/tests/tests_integration.py
@@ -14,50 +14,7 @@ from formidable.accesses import get_accesses
 from formidable.forms import FormidableForm, fields
 from formidable import validators, constants
 
-form_data = {
-    "label": "test create",
-    "description": "my first formidable by api",
-    "fields": [
-        {
-            "label": "hello",
-            "slug": "textslug",
-            "type_id": "text",
-            "placeholder": None,
-            "help_text": None,
-            "default": None,
-            "accesses": [
-                {"access_id": "padawan", "level": "REQUIRED"},
-                {"access_id": "jedi", "level": "EDITABLE"},
-                {"access_id": "jedi-master", "level": "READONLY"},
-                {"access_id": "human", "level": "HIDDEN"},
-            ]
-        },
-    ]
-}
-
-form_data_items = {
-    "label": "test create",
-    "description": "my first formidable by api",
-    "fields": [{
-        "label": "my_dropdwon",
-        "slug": "dropdown_slug",
-        "type_id": "dropdown",
-        "placeholder": None,
-        "help_text": "Lesfrites c'est bon",
-        "default": None,
-        "accesses": [
-            {"access_id": "padawan", "level": "REQUIRED"},
-            {"access_id": "jedi", "level": "EDITABLE"},
-            {"access_id": "jedi-master", "level": "READONLY"},
-            {"access_id": "human", "level": "HIDDEN"},
-        ],
-        "items": [
-            {'value': 'tuto', 'label': 'toto'},
-            {'value': 'plop', 'label': 'coin'},
-        ],
-        "multiple": False
-    }]
-}
+from . import form_data, form_data_items
 
 
 class CreateFormTestCase(APITestCase):

--- a/docs/source/callbacks.rst
+++ b/docs/source/callbacks.rst
@@ -1,0 +1,42 @@
+=========
+Callbacks
+=========
+
+.. versionadded:: 0.5
+
+Each time a formidable form is created or updated, the API views are able to call a function that can help you trigger actions. For example, you can use the :mod:`django.contrib.messages` to inform your current user that their form has been successfully saved or that a problem has occurred ; or send an email or ping an API, or... whatever you want.
+
+By default, the view won't load and launch anything. In order to set a callback up, you'll need to give a value to any of the following variables:
+
+* ``FORMIDABLE_POST_CREATE_CALLBACK_SUCCESS``: callback to call when form creation is successful.
+* ``FORMIDABLE_POST_CREATE_CALLBACK_FAIL``: callback to call when form creation has failed.
+* ``FORMIDABLE_POST_UPDATE_CALLBACK_SUCCESS``: callback to call when form update is successful.
+* ``FORMIDABLE_POST_UPDATE_CALLBACK_FAIL``: callback to call when form update has failed.
+
+The callback functions
+----------------------
+
+A callback function is a function that accepts only one argument, the `request` object coming from the API View. It doesn't have to return anything, it can make multiple calls... it's up to you.
+
+.. code-block:: python
+
+    def callback_on_success(request):
+        mail.send(request.user.email, 'All is fine')
+
+.. warning::
+
+    the DRF request is not inherited from django core, :class:`HTTPRequest`, and you should not assume they'll behave the same way. It shares some properties, so it may quack like a duck, but it's not a duck.
+
+    If you need the "true" HTTPRequest object, use ``self.request._request``. That might be the case if you want to use the :mod:`django.contrib.messages`.
+
+    .. code-block:: python
+
+        def callback_on_success(request):
+            messages.info(request._request, "Your form is recorded")
+
+Fails silently
+--------------
+
+At the moment, if your callback fails for some reason and throws an exception, the exception is logged and the error is skipped. We've decided not to re-raise the exception to avoid your database transaction to be rolled back and the form you've tried to save being lost. After all, it's not the users fault if the callback has failed, but the integrator's.
+
+At some point, we may add a "fail" mode and re-raise the exception and allow the integrator to make sure that the DB transaction is either committed if everything is fine, or aborted if something bad happened in the callback function.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,7 @@ Contents:
    intro
    install
    forms
+   callbacks
    dev
 
 

--- a/formidable/__init__.py
+++ b/formidable/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'formidable.app.FormidableConfig'

--- a/formidable/app.py
+++ b/formidable/app.py
@@ -1,0 +1,23 @@
+"""
+Django-formidable app definition.
+
+The :class:`FormidableConfig` checks various configuration settings:
+
+* post-update and post-create callbacks
+"""
+
+from django.apps import AppConfig
+
+
+class FormidableConfig(AppConfig):
+    """
+    Formidable application configuration class. Runs various checks.
+    """
+    name = 'formidable'
+
+    def ready(self):
+        """
+        Run various checks when ready
+        """
+        from .views import check_callback_configuration
+        check_callback_configuration()

--- a/formidable/views.py
+++ b/formidable/views.py
@@ -99,12 +99,21 @@ class FormidableCreate(six.with_metaclass(MetaClassView, CreateAPIView)):
 
             if callback:
                 module, meth_name = callback.rsplit('.', 1)
-                if six.PY3:
-                    imported_module = importlib.import_module(module)
-                else:
-                    imported_module = importlib.import_module(
-                        module, [meth_name])
-                func = getattr(imported_module, meth_name)
+                try:
+                    if six.PY3:
+                        imported_module = importlib.import_module(module)
+                    else:
+                        imported_module = importlib.import_module(
+                            module, [meth_name])
+                    func = getattr(imported_module, meth_name)
+                except ImportError:
+                    logger.error(
+                        "An error has occurred impossible to import %s",
+                        callback
+                    )
+                    return response
+
+                # it's possible to import. Let's try to run it
                 try:
                     func(request)
                 except Exception:

--- a/formidable/views.py
+++ b/formidable/views.py
@@ -73,6 +73,12 @@ class CallbackMixin(object):
     def _call_callback(self, callback):
         """
         Tool to simply call the callback function and handle edge-cases.
+
+        **WARNING!** the DRF request is not inherited from django core,
+        `HTTPRequest`, and you should not assume they'll behave the same way.
+
+        If you need the "true" HTTPRequest object,
+        use ``self.request._request`` in your callback functions.
         """
         # If there's no callback value, it's pointless to try to extract it
         if not callback:
@@ -83,6 +89,11 @@ class CallbackMixin(object):
         if not func:
             return
         try:
+            # WARNING! the DRF request is not inherited from django core,
+            # `HTTPRequest`, and you should not assume they'll behave the same
+            # way.
+            # If you need the "true" HTTPRequest object, use
+            # ``self.request._request``
             func(self.request)
         except Exception:
             logger.error(

--- a/formidable/views.py
+++ b/formidable/views.py
@@ -51,6 +51,62 @@ def extract_function(func_name):
     return func
 
 
+class CallbackMixin(object):
+    success_callback_settings = ''
+    failure_callback_settings = ''
+    callback_error_message = "An error has occurred with function: `%s`"
+
+    def _call_callback(self, callback):
+        """
+        Tool to simply call the callback function and handle edge-cases.
+        """
+        func = extract_function(callback)
+        # Call function only if existing
+        if not func:
+            return
+        try:
+            func(self.request)
+        except Exception:
+            logger.error(
+                self.callback_error_message, callback
+            )
+
+    def success_callback(self):
+        """
+        Call the failure callback function
+        """
+        callback = getattr(settings, self.success_callback_settings, None)
+        self._call_callback(callback)
+
+    def failure_callback(self):
+        """
+        Call the failure callback function
+        """
+        # Extract the callback function
+        callback = getattr(settings, self.failure_callback_settings, None)
+        self._call_callback(callback)
+
+    def perform_create(self, serializer):
+        response = super(CallbackMixin, self).perform_create(serializer)
+        self.success_callback()
+        return response
+
+    def perform_update(self, serializer):
+        "Perform update (overridden to handle callbacks)"
+        response = super(CallbackMixin, self).perform_update(serializer)
+        self.success_callback()
+        return response
+
+    def handle_exception(self, exc):
+        "Handle errors/exceptions (overridden to handle callbacks)"
+        response = super(CallbackMixin, self).handle_exception(exc)
+        # Don't bother with the callback if it was a wrong method
+        if isinstance(exc, exceptions.MethodNotAllowed):
+            return response
+        self.failure_callback()
+        return response
+
+
 class MetaClassView(type):
     """
     Automatically load the *list* of permissions defined in the settings.
@@ -84,48 +140,12 @@ class MetaClassView(type):
 
 
 class FormidableDetail(six.with_metaclass(MetaClassView,
-                       RetrieveUpdateAPIView)):
-
+                       CallbackMixin, RetrieveUpdateAPIView)):
     queryset = Formidable.objects.all()
     serializer_class = FormidableSerializer
     settings_permission_key = 'FORMIDABLE_PERMISSION_BUILDER'
-
-    def perform_update(self, serializer):
-        response = super(FormidableDetail, self).perform_update(serializer)
-        # Extract the callback function
-        callback = getattr(
-            settings, 'FORMIDABLE_POST_UPDATE_CALLBACK_SUCCESS', None)
-        func = extract_function(callback)
-        try:
-            # Call function only if existing
-            if func:
-                func(self.request)
-        except Exception:
-            logger.error(
-                "An error has occurred with post_update function %s", func
-            )
-        return response
-
-    def handle_exception(self, exc):
-        response = super(FormidableDetail, self).handle_exception(exc)
-        # Don't bother with the callback if it was a wrong method
-        if isinstance(exc, exceptions.MethodNotAllowed):
-            return response
-
-        # Extract the callback function
-        callback = getattr(
-            settings, 'FORMIDABLE_POST_UPDATE_CALLBACK_FAIL', None)
-        func = extract_function(callback)
-        try:
-            # Call function only if existing
-            if func:
-                func(self.request)
-        except Exception:
-            logger.error(
-                "An error has occurred with post_update failure function %s",
-                func
-            )
-        return response
+    success_callback_settings = 'FORMIDABLE_POST_UPDATE_CALLBACK_SUCCESS'
+    failure_callback_settings = 'FORMIDABLE_POST_UPDATE_CALLBACK_FAIL'
 
     def get_queryset(self):
         qs = super(FormidableDetail, self).get_queryset()
@@ -133,55 +153,13 @@ class FormidableDetail(six.with_metaclass(MetaClassView,
         return qs.prefetch_related(Prefetch('fields', queryset=field_qs))
 
 
-class FormidableCreate(six.with_metaclass(MetaClassView, CreateAPIView)):
+class FormidableCreate(six.with_metaclass(MetaClassView,
+                       CallbackMixin, CreateAPIView)):
     queryset = Formidable.objects.all()
     serializer_class = FormidableSerializer
     settings_permission_key = 'FORMIDABLE_PERMISSION_BUILDER'
-
-    def perform_create(self, serializer):
-        response = super(FormidableCreate, self).perform_create(serializer)
-        # Extract the callback function
-        callback = getattr(
-            settings, 'FORMIDABLE_POST_CREATE_CALLBACK_SUCCESS', None)
-        func = extract_function(callback)
-        try:
-            # Call function only if existing
-            if func:
-                func(self.request)
-        except Exception:
-            logger.error(
-                "An error has occurred with post_create function %s", func
-            )
-        return response
-
-    def handle_exception(self, exc):
-        response = super(FormidableCreate, self).handle_exception(exc)
-        # Don't bother with the callback if it was a wrong method
-        if isinstance(exc, exceptions.MethodNotAllowed):
-            return response
-
-        # Extract the callback function
-        callback = getattr(
-            settings, 'FORMIDABLE_POST_CREATE_CALLBACK_FAIL', None)
-        func = extract_function(callback)
-        try:
-            # Call function only if existing
-            if func:
-                func(self.request)
-        except Exception:
-            logger.error(
-                "An error has occurred with post_create failure function %s",
-                func
-            )
-        return response
-
-    def dispatch(self, request, *args, **kwargs):
-        # Being forced to do this in dispatch() rather than post() because
-        # ValidationErrors can be raised in dispatch and we don't go through
-        # the post() method
-        response = super(FormidableCreate, self).dispatch(
-            request, *args, **kwargs)
-        return response
+    success_callback_settings = 'FORMIDABLE_POST_CREATE_CALLBACK_SUCCESS'
+    failure_callback_settings = 'FORMIDABLE_POST_CREATE_CALLBACK_FAIL'
 
 
 class ContextFormDetail(six.with_metaclass(MetaClassView, RetrieveAPIView)):

--- a/formidable/views.py
+++ b/formidable/views.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import importlib
+import logging
 
 from django.conf import settings
 from django.db.models import Prefetch
@@ -24,6 +25,9 @@ from formidable.models import Field, Formidable
 from formidable.serializers import FormidableSerializer, SimpleAccessSerializer
 from formidable.serializers.forms import ContextFormSerializer
 from formidable.serializers.presets import PresetsSerializer
+
+
+logger = logging.getLogger(__name__)
 
 
 class MetaClassView(type):
@@ -101,7 +105,13 @@ class FormidableCreate(six.with_metaclass(MetaClassView, CreateAPIView)):
                     imported_module = importlib.import_module(
                         module, [meth_name])
                 func = getattr(imported_module, meth_name)
-                func(request)
+                try:
+                    func(request)
+                except Exception:
+                    logger.error(
+                        "An error has occurred with post_create function %s",
+                        func
+                    )
         return response
 
 

--- a/formidable/views.py
+++ b/formidable/views.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import importlib
+
 from django.conf import settings
 from django.db.models import Prefetch
 
@@ -73,6 +75,34 @@ class FormidableCreate(six.with_metaclass(MetaClassView, CreateAPIView)):
     queryset = Formidable.objects.all()
     serializer_class = FormidableSerializer
     settings_permission_key = 'FORMIDABLE_PERMISSION_BUILDER'
+
+    def dispatch(self, request, *args, **kwargs):
+        # Being forced to do this in dispatch() rather than post() because
+        # ValidationErrors can be raised in dispatch and we don't go through
+        # the post() method
+        response = super(FormidableCreate, self).dispatch(
+            request, *args, **kwargs)
+
+        # Is the response a success or a failure?
+        if request.method == 'POST':
+            success = response.status_code == 201
+            if success:
+                callback = getattr(
+                    settings, 'FORMIDABLE_POST_CREATE_CALLBACK_SUCCESS', None)
+            else:
+                callback = getattr(
+                    settings, 'FORMIDABLE_POST_CREATE_CALLBACK_FAIL', None)
+
+            if callback:
+                module, meth_name = callback.rsplit('.', 1)
+                if six.PY3:
+                    imported_module = importlib.import_module(module)
+                else:
+                    imported_module = importlib.import_module(
+                        module, [meth_name])
+                func = getattr(imported_module, meth_name)
+                func(request)
+        return response
 
 
 class ContextFormDetail(six.with_metaclass(MetaClassView, RetrieveAPIView)):

--- a/formidable/views.py
+++ b/formidable/views.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import importlib
 import logging
 
 from django.conf import settings
@@ -13,7 +12,7 @@ from rest_framework.generics import (
     CreateAPIView, RetrieveAPIView, RetrieveUpdateAPIView
 )
 from rest_framework.response import Response
-from rest_framework.settings import perform_import
+from rest_framework.settings import import_from_string, perform_import
 from rest_framework.views import APIView
 
 from formidable.accesses import get_accesses, get_context
@@ -26,7 +25,6 @@ from formidable.serializers import FormidableSerializer, SimpleAccessSerializer
 from formidable.serializers.forms import ContextFormSerializer
 from formidable.serializers.presets import PresetsSerializer
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -35,19 +33,12 @@ def extract_function(func_name):
     Return a function out of a namespace
     """
     func = None
-    if func_name:
-        module, meth_name = func_name.rsplit('.', 1)
-        try:
-            if six.PY3:
-                imported_module = importlib.import_module(module)
-            else:
-                imported_module = importlib.import_module(
-                    module, [meth_name])
-            func = getattr(imported_module, meth_name)
-        except ImportError:
-            logger.error(
-                "An error has occurred impossible to import %s", func_name
-            )
+    try:
+        func = import_from_string(func_name, '')
+    except ImportError:
+        logger.error(
+            "An error has occurred impossible to import %s", func_name
+        )
     return func
 
 
@@ -60,6 +51,10 @@ class CallbackMixin(object):
         """
         Tool to simply call the callback function and handle edge-cases.
         """
+        # If there's no callback value, it's pointless to try to extract it
+        if not callback:
+            return
+
         func = extract_function(callback)
         # Call function only if existing
         if not func:

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     ; Requirements from demo project
+    py27: mock
     -rdemo/requirements-demo.pip
 commands =
     python --version


### PR DESCRIPTION
TODO 

- [x] factorize redundant code
- [x] don't use the ``func`` variable in logs, rather the namespace string.
