### PR TITLE
moving isort tests to the tox file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Release 0.4.0dev (unreleased)
 * Added flake8 checks via tox (#133).
 * Added tox posargs to pass extra arguments when running tests (#135).
 * Solve ``setup.py install`` "zip" error. Skip global package installation (#139).
+* Moving ``check-python-imports`` test to the tox file (#138).
 
 Release 0.3.1 (2016-11-04)
 ==========================

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ check-python-imports: install-isort
 	@cat setup.cfg
 	isort --check-only --recursive --verbose formidable
 
+# target: test - run all tests (unittests + linters)
+.PHONY: test
+test:
+    tox -r
 
 # target: docs - build the sphinx documentation
 .PHONY: docs

--- a/circle.yml
+++ b/circle.yml
@@ -9,4 +9,3 @@ dependencies:
 test:
     override:
         - tox -r
-        - make check-python-imports

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     django18-py{27,33,34,35}
     django19-py{27,34,35}
     flake8
+    check-python-imports
 skip_missing_interpreters = True
 
 [testenv]
@@ -25,6 +26,15 @@ changedir =
 deps = flake8
 commands =
     flake8 .
+
+[testenv:check-python-imports]
+changedir =
+    {toxinidir}
+deps = isort
+whitelist_externals = cat
+commands =
+    cat setup.cfg
+    isort --check-only --recursive --verbose formidable
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
Use-case: Developer "X" is working on a feature, and is adding a "isort" regression somewhere.

Issue: "X" is pushing the new branch and it fails because **CircleCI** launches two commands: tox & the isort check.

Solution: since isort is a Python dependency and that tox knows how to install python packages in an isolated environment, tox is able to perform this extra check without having to run two commands. *"One command to rule them all"*.

ToDo:

- [x] Changelog
- [x] Revamp the makefile a bit to add a ``make test`` target.