### PR TITLE
Fix setup.py install bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Release 0.4.0dev (unreleased)
 * Fix autodoc generation (#131).
 * Added flake8 checks via tox (#133).
 * Added tox posargs to pass extra arguments when running tests (#135).
+* Solve ``setup.py install`` "zip" error. Skip global package installation (#139).
 
 Release 0.3.1 (2016-11-04)
 ==========================

--- a/circle.yml
+++ b/circle.yml
@@ -3,8 +3,8 @@ machine:
     - pyenv global 2.7.10 3.3.3 3.4.3 3.5.0
 
 dependencies:
-    pre:
-        - pip install tox
+    override:
+        - pip install --upgrade tox
 
 test:
     override:


### PR DESCRIPTION
It looks like the ``.egg`` file generated when build "N" is happening is not always wiped out at the end of this build. As a consequence, the build "N+1" can't start because there's a "zip error" similar to [this trac issue](https://trac.edgewall.org/ticket/7014).

As a matter of fact, the global ``python setup.py install`` is useless, since `tox` will install the package in each isolated virtualenv. So the solution to this issue was to *override* the dependency setup by installing the most recent version of tox and avoid the misbehaving command