### PR TITLE
Fix demo site for logged in users

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ ChangeLog
 Release 0.5.0dev (unreleased)
 =============================
 
-* Nothing change yet.
+* Fix the demo site to work with Django 1.8 *and* with logged-in users (#146).
 
 
 Release 0.4.0 (2017-04-01)

--- a/demo/demo/builder/static/assets/csrftoken.js
+++ b/demo/demo/builder/static/assets/csrftoken.js
@@ -1,0 +1,9 @@
+function setupCRSFToken(csrftoken) {
+  $.ajaxSetup({
+    beforeSend: function(xhr, settings) {
+      if (!/^(GET|HEAD|OPTIONS|TRACE)$/.test(settings.type) && !this.crossDomain) {
+        xhr.setRequestHeader("X-CSRFToken", csrftoken);
+      }
+    }
+  });
+}

--- a/demo/demo/builder/templates/formidable/formidable_base.html
+++ b/demo/demo/builder/templates/formidable/formidable_base.html
@@ -13,6 +13,12 @@
     <link rel="stylesheet" href="{% static "assets/formidable.css" %}">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/js/bootstrap.min.js" crossorigin="anonymous"></script>
+    <script src="{% static "assets/csrftoken.js" %}"></script>
+    <script type="text/javascript">
+        $(document).ready(function() {
+            setupCRSFToken('{{ csrf_token }}');
+        });
+    </script>
     <style>
       .title {
         padding: 20px 15px;

--- a/demo/demo/builder/urls.py
+++ b/demo/demo/builder/urls.py
@@ -3,7 +3,6 @@ from django.conf.urls import url
 from demo.builder import views
 
 urlpatterns = [
-    r'',
     url(r'^$',
         views.FormidableListView.as_view(),
         name='formidable-list'),

--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = (
 )
 
 MIDDLEWARE_CLASSES = (
+    'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -136,3 +136,28 @@ by ``FORMIDABLE_PERMISSION_BUILDER``)
 ``FORMIDABLE_PERMISSION_USING``).
 
 You can provide any permissions you want.
+
+CSRF
+----
+
+If you're dealing with logged-in users (you surely do), you're going to need to provide a CSRF Token when validating a creation or an edit form. If you don't provide it *or* if your CSRF is misconfigured, you'll receive a ``403`` error when trying to save your forms.
+
+In order to do so, you'll have to use a code similar to this:
+
+.. literalinclude:: ../../demo/demo/builder/static/assets/csrftoken.js
+    :language: javascript
+
+.. warning:: you'll have to make sure that your CSRF configuration is properly set (middlewares, context managers, etc).
+
+Then in your templates, those that'll have to display and handle the form editor, you'll have to call this function like this:
+
+.. code-block:: js
+
+    <script src="{% static "assets/csrftoken.js" %}"></script>
+    <script type="text/javascript">
+        $(document).ready(function() {
+            setupCRSFToken('{{ csrf_token }}');
+        });
+    </script>
+
+This way, every AJAX call coming from this template will provide a token that'll fit Django's (and Django REST Framework) requirements.


### PR DESCRIPTION
### TODO

- [x] documentation on using csrftoken for integration, warn integrators with the fact that logged-in users should provide a csrf token in their AJAX calls

### How to test

* Once your virtualenv is installed (using only Django<1.9 at the moment), you can log on the website using the ``/admin`` URL.
* access the ``forms/`` URL and try to edit a form,
* if you try to save, it works.

Try with removing the ``setupCSRFToken()`` call in the ``demo/demo/builder/templates/formidable/formidable_base.html `` file.

If you try to save, it throws a 403. You can inspect if using your favorite browser dev tool, it's about CSRF value not provided.

**Note:** you can't use the master code, it breaks because of the empty URL in the urlpatterns.