### PR TITLE
Deduplicate sql Queries in ContextFormDetailView

### DIFF
--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/1.8/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
+import django
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -80,9 +81,14 @@ WSGI_APPLICATION = 'demo.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases
 
+if django.VERSION[:2] == (1, 8):
+    engine = 'django18_sqlite3_backend'
+else:
+    engine = 'django.db.backends.sqlite3',
+
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
+        'ENGINE': engine,
         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
     }
 }

--- a/demo/django18_sqlite3_backend/__init__.py
+++ b/demo/django18_sqlite3_backend/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding:utf-8 -*-
+# flake8: noqa
+from __future__ import absolute_import, division, print_function, unicode_literals

--- a/demo/django18_sqlite3_backend/base.py
+++ b/demo/django18_sqlite3_backend/base.py
@@ -1,0 +1,14 @@
+# -*- coding:utf-8 -*-
+# flake8: noqa
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from django.db.backends.sqlite3.base import DatabaseWrapper as OrigDatabaseWrapper
+
+from .operations import DatabaseOperations
+
+
+class DatabaseWrapper(OrigDatabaseWrapper):
+
+    def __init__(self, *args, **kwargs):
+        super(DatabaseWrapper, self).__init__(*args, **kwargs)
+        self.ops = DatabaseOperations(self)

--- a/demo/django18_sqlite3_backend/operations.py
+++ b/demo/django18_sqlite3_backend/operations.py
@@ -1,0 +1,43 @@
+# -*- coding:utf-8 -*-
+# flake8: noqa
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from django.db.backends.sqlite3.operations import DatabaseOperations as OrigDatabaseOperations
+
+
+class DatabaseOperations(OrigDatabaseOperations):
+
+    # From Django commit 4f6a7663bcddffb114f2647f9928cbf1fdd8e4b5
+
+    def _quote_params_for_last_executed_query(self, params):
+        """
+        Only for last_executed_query! Don't use this to execute SQL queries!
+        """
+        sql = 'SELECT ' + ', '.join(['QUOTE(?)'] * len(params))
+        # Bypass Django's wrappers and use the underlying sqlite3 connection
+        # to avoid logging this query - it would trigger infinite recursion.
+        cursor = self.connection.connection.cursor()
+        # Native sqlite3 cursors cannot be used as context managers.
+        try:
+            return cursor.execute(sql, params).fetchone()
+        finally:
+            cursor.close()
+
+    def last_executed_query(self, cursor, sql, params):
+        # Python substitutes parameters in Modules/_sqlite/cursor.c with:
+        # pysqlite_statement_bind_parameters(self->statement, parameters, allow_8bit_chars);
+        # Unfortunately there is no way to reach self->statement from Python,
+        # so we quote and substitute parameters manually.
+        if params:
+            if isinstance(params, (list, tuple)):
+                params = self._quote_params_for_last_executed_query(params)
+            else:
+                keys = params.keys()
+                values = tuple(params.values())
+                values = self._quote_params_for_last_executed_query(values)
+                params = dict(zip(keys, values))
+            return sql % params
+        # For consistency with SQLiteCursorWrapper.execute(), just return sql
+        # when there are no parameters. See #13648 and #17158.
+        else:
+            return sql

--- a/demo/requirements-demo.pip
+++ b/demo/requirements-demo.pip
@@ -2,3 +2,4 @@ django-cors-headers
 ipdb
 django-extensions
 freezegun
+django-perf-rec

--- a/demo/tests/perfs/test_end_point.perf.yml
+++ b/demo/tests/perfs/test_end_point.perf.yml
@@ -1,0 +1,6 @@
+RenderContextSerializer.test_queryset:
+- db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = # ORDER BY "formidable_field"."order" ASC'
+- db: 'SELECT ... FROM "formidable_access" WHERE ("formidable_access"."access_id" = # AND NOT ("formidable_access"."level" = #) AND "formidable_access"."field_id" IN (...))'
+- db: SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...) ORDER BY "formidable_item"."order" ASC
+- db: SELECT ... FROM "formidable_validation" WHERE "formidable_validation"."field_id" IN (...)
+- db: SELECT ... FROM "formidable_default" WHERE "formidable_default"."field_id" IN (...)

--- a/demo/tests/perfs/tests_integration.perf.yml
+++ b/demo/tests/perfs/tests_integration.perf.yml
@@ -1,8 +1,7 @@
 TestContextFormEndPoint.test_queryset:
 - db: 'SELECT ... FROM "django_session" WHERE ("django_session"."expire_date" > # AND "django_session"."session_key" = #)'
 - db: 'SELECT ... FROM "formidable_formidable" WHERE "formidable_formidable"."id" = #'
-- db: SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" IN (#) ORDER BY "formidable_field"."order" ASC
-- db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = #'
+- db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = # ORDER BY "formidable_field"."order" ASC'
 - db: 'SELECT ... FROM "formidable_access" WHERE ("formidable_access"."access_id" = # AND NOT ("formidable_access"."level" = #) AND "formidable_access"."field_id" IN (...))'
 - db: SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...) ORDER BY "formidable_item"."order" ASC
 - db: SELECT ... FROM "formidable_validation" WHERE "formidable_validation"."field_id" IN (...)

--- a/demo/tests/perfs/tests_integration.perf.yml
+++ b/demo/tests/perfs/tests_integration.perf.yml
@@ -1,0 +1,9 @@
+TestContextFormEndPoint.test_queryset:
+- db: 'SELECT ... FROM "django_session" WHERE ("django_session"."expire_date" > # AND "django_session"."session_key" = #)'
+- db: 'SELECT ... FROM "formidable_formidable" WHERE "formidable_formidable"."id" = #'
+- db: SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" IN (#) ORDER BY "formidable_field"."order" ASC
+- db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = #'
+- db: 'SELECT ... FROM "formidable_access" WHERE ("formidable_access"."access_id" = # AND NOT ("formidable_access"."level" = #) AND "formidable_access"."field_id" IN (...))'
+- db: SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...) ORDER BY "formidable_item"."order" ASC
+- db: SELECT ... FROM "formidable_validation" WHERE "formidable_validation"."field_id" IN (...)
+- db: SELECT ... FROM "formidable_default" WHERE "formidable_default"."field_id" IN (...)

--- a/demo/tests/test_end_point.py
+++ b/demo/tests/test_end_point.py
@@ -5,6 +5,7 @@ import copy
 from functools import reduce
 
 from django.test import TestCase
+import django_perf_rec
 
 from formidable import constants
 from formidable.models import Formidable
@@ -297,6 +298,21 @@ class RenderContextSerializer(TestCase):
         self.assertIn('defaults', field)
         defaults = field['defaults']
         self.assertEqual(defaults, ['Roméo'])
+
+    def test_queryset(self):
+
+        class TestForm(FormidableForm):
+            name = fields.CharField(label='Your name', default='Roméo')
+            label = fields.CharField(label='label', default='Roméo')
+            salary = fields.IntegerField()
+            birthdate = fields.DateField()
+
+        form = TestForm.to_formidable(label='title')
+
+        serializer = ContextFormSerializer(form, context={'role': 'jedi'})
+
+        with django_perf_rec.record(path='perfs/'):
+            serializer.data
 
 
 class CreateSerializerTestCase(TestCase):

--- a/demo/tests/tests_integration.py
+++ b/demo/tests/tests_integration.py
@@ -248,6 +248,29 @@ class MyForm(FormidableForm):
     )
 
 
+class TestContextFormEndPoint(APITestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        class MyTestForm(MyForm):
+            phone = fields.IntegerField()
+
+        super(TestContextFormEndPoint, cls).setUpClass()
+        cls.form = MyForm.to_formidable(label='test')
+
+    def test_queryset(self):
+        import django_perf_rec
+
+        session = self.client.session
+        session['role'] = 'padawan'
+        session.save()
+
+        with django_perf_rec.record(path='perfs/'):
+            self.client.get(reverse(
+                'formidable:context_form_detail', args=[self.form.pk])
+            )
+
+
 class TestValidationEndPoint(APITestCase):
 
     def setUp(self):

--- a/formidable/serializers/fields.py
+++ b/formidable/serializers/fields.py
@@ -8,7 +8,7 @@ from django.utils.functional import cached_property
 from rest_framework import serializers
 
 from formidable import constants
-from formidable.models import Access, Field
+from formidable.models import Access, Field, Item
 from formidable.register import FieldSerializerRegister, load_serializer
 from formidable.serializers.access import AccessSerializer
 from formidable.serializers.child_proxy import LazyChildProxy
@@ -95,7 +95,11 @@ class ListContextFieldSerializer(serializers.ListSerializer):
         qs = super(ListContextFieldSerializer, self).get_attribute(instance)
         access_qs = Access.objects.filter(access_id=self.role)
         access_qs = access_qs.exclude(level=constants.HIDDEN)
-        qs = qs.prefetch_related(Prefetch('accesses', queryset=access_qs))
+        qs = qs.prefetch_related(
+            Prefetch('accesses', queryset=access_qs),
+            Prefetch('items', queryset=Item.objects.order_by('order')),
+            'validations', 'defaults',
+        )
         return qs
 
     def to_representation(self, fields):

--- a/formidable/serializers/items.py
+++ b/formidable/serializers/items.py
@@ -20,11 +20,6 @@ class ItemListSerializer(NestedListSerializer):
 
         return data
 
-    def to_representation(self, items):
-        return super(ItemListSerializer, self).to_representation(
-            items.order_by('order')
-        )
-
 
 class ItemSerializer(serializers.ModelSerializer):
 

--- a/formidable/urls.py
+++ b/formidable/urls.py
@@ -4,7 +4,7 @@ from formidable import views
 
 urlpatterns = [
     url(r'^forms/(?P<pk>\d+)/$', views.ContextFormDetail.as_view(),
-        name='form_detail'),
+        name='context_form_detail'),
     url(r'^forms/(?P<pk>\d+)/validate/$', views.ValidateView.as_view(),
         name='form_validation'),
     url(r'^builder/forms/(?P<pk>\d+)/$', views.FormidableDetail.as_view(),

--- a/formidable/views.py
+++ b/formidable/views.py
@@ -197,11 +197,6 @@ class ContextFormDetail(six.with_metaclass(MetaClassView, RetrieveAPIView)):
     serializer_class = ContextFormSerializer
     settings_permission_key = 'FORMIDABLE_PERMISSION_USING'
 
-    def get_queryset(self):
-        qs = super(ContextFormDetail, self).get_queryset()
-        field_qs = Field.objects.order_by('order')
-        return qs.prefetch_related(Prefetch('fields', queryset=field_qs))
-
     def get_serializer_context(self):
         context = super(ContextFormDetail, self).get_serializer_context()
         context['role'] = get_context(self.request, self.kwargs)


### PR DESCRIPTION
- [x] Introduce django-perf-rec inside django-formidable
- [x] Deduplicate any queries on the view
- [x] Able to use the ContexFormSerializer without manupulating queryset in each context.


### Comparison: render a form on "padawan" context with three different fields.

In Master

```sql
- db: 'SELECT ... FROM "django_session" WHERE ("django_session"."expire_date" > # AND "django_session"."session_key" = #)'
- db: 'SELECT ... FROM "formidable_formidable" WHERE "formidable_formidable"."id" = #'
- db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" IN (#) ORDER BY "formidable_field"."order" ASC
- db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = # ORDER BY "formidable_field"."order" ASC'
- db: 'SELECT ... FROM "formidable_access" WHERE ("formidable_access"."access_id" = # AND NOT ("formidable_access"."level" = #) AND "formidable_access"."field_id" IN (...))'
- db: 'SELECT ... FROM "formidable_validation" WHERE "formidable_validation"."field_id" = #'
- db: 'SELECT ... FROM "formidable_access" WHERE ("formidable_access"."field_id" = # AND "formidable_access"."access_id" = #)'
- db: 'SELECT ... FROM "formidable_access" WHERE ("formidable_access"."field_id" = # AND "formidable_access"."access_id" = #)'
- db: 'SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" = # ORDER BY "formidable_item"."order" ASC'
- db: 'SELECT ... FROM "formidable_default" WHERE "formidable_default"."field_id" = #'
- db: 'SELECT ... FROM "formidable_validation" WHERE "formidable_validation"."field_id" = #'
- db: 'SELECT ... FROM "formidable_access" WHERE ("formidable_access"."field_id" = # AND "formidable_access"."access_id" = #)'
- db: 'SELECT ... FROM "formidable_access" WHERE ("formidable_access"."field_id" = # AND "formidable_access"."access_id" = #)'
- db: 'SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" = # ORDER BY "formidable_item"."order" ASC'
- db: 'SELECT ... FROM "formidable_default" WHERE "formidable_default"."field_id" = #'
```

In current branch

```sql
- db: 'SELECT ... FROM "django_session" WHERE ("django_session"."expire_date" > # AND "django_session"."session_key" = #)'
- db: 'SELECT ... FROM "formidable_formidable" WHERE "formidable_formidable"."id" = #'
- db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = # ORDER BY "formidable_field"."order" ASC'
- db: 'SELECT ... FROM "formidable_access" WHERE ("formidable_access"."access_id" = # AND NOT ("formidable_access"."level" = #) AND "formidable_access"."field_id" IN (...))'
- db: SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...) ORDER BY "formidable_item"."order" ASC
- db: SELECT ... FROM "formidable_validation" WHERE "formidable_validation"."field_id" IN (...)
- db: SELECT ... FROM "formidable_default" WHERE "formidable_default"."field_id" IN (...)
```