### PR TITLE
[setup] Expose version in formidable package

### DIFF
--- a/formidable/__init__.py
+++ b/formidable/__init__.py
@@ -1,1 +1,3 @@
 default_app_config = 'formidable.app.FormidableConfig'
+
+version = '0.6.0.dev0'

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,15 @@ from __future__ import unicode_literals
 import os
 from setuptools import setup, find_packages
 
+import formidable
+
+
 with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
     README = readme.read()
 
 setup(
     name='django-formidable',
-    version='0.6.0.dev0',
+    version=formidable.version,
     packages=find_packages(),
     include_package_data=True,
     license='BSD License',


### PR DESCRIPTION
## Rationale

Since the version is set in `setup.py`, it's not available in formidable
module itself. I suggest to set the version in `formidable/__init__.py`
instead.