### PR TITLE
Provide a tools in order to generate django-form class from json contextualized definition

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ master (unreleased)
 * Fixed the swagger doc generation and rendering (#210).
 * Fix wrong field type for Checkbox (#208).
 * Don't rely on database ordering in `NestedListSerializer` (#215)
+* Provide a tools in order to generate django-form class from json
+  contextualized definition (#171)
 
 Release 0.8.2 (2017-03-28)
 ==========================

--- a/demo/tests/test_form_from_schema.py
+++ b/demo/tests/test_form_from_schema.py
@@ -69,6 +69,28 @@ class TestFormFromSchema(TestCase):
         self.assertEqual(type(charfield.widget), forms.Textarea)
         self.assertFalse(charfield.required)
 
+    def test_help_text(self):
+        class TestHelpTextField(FormidableForm):
+            """
+            Test help text
+
+            """
+            helptext = fields.HelpTextField(text='My Help Text')
+
+        formidable = TestHelpTextField.to_formidable(label='label')
+        schema = ContextFormSerializer(instance=formidable, context={
+            'role': 'jedi'
+        }).data
+
+        form_class = get_dynamic_form_class_from_schema(schema)
+        form = form_class()
+
+        self.assertIn('helptext', form.fields)
+        helptext = form.fields['helptext']
+        self.assertEqual(type(helptext), fields.HelpTextField)
+        self.assertEqual(type(helptext.widget), widgets.HelpTextWidget)
+        self.assertFalse(helptext.required)
+
     def test_checkbox_field(self):
         class TestCheckBoxField(FormidableForm):
             """ Test checkbox """

--- a/demo/tests/test_form_from_schema.py
+++ b/demo/tests/test_form_from_schema.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+from django.test import TestCase
+from django import forms
+
+from formidable.constants import REQUIRED
+from formidable.forms import (
+    FormidableForm, fields, get_dynamic_form_class_from_schema
+)
+from formidable.forms import widgets
+from formidable.serializers.forms import ContextFormSerializer
+
+
+class TestFormFromSchema(TestCase):
+
+    def test_charfield(self):
+        class TestCharField(FormidableForm):
+            """ Test charfield """
+            charfield = fields.CharField()
+
+        formidable = TestCharField.to_formidable(label='label')
+        schema = ContextFormSerializer(instance=formidable, context={
+            'role': 'jedi'
+        }).data
+        form = get_dynamic_form_class_from_schema(schema)()
+        self.assertIn('charfield', form.fields)
+        charfield = form.fields['charfield']
+        self.assertEqual(type(charfield), forms.CharField)
+        self.assertFalse(charfield.required)
+
+    def test_required_charfield(self):
+        class TestCharField(FormidableForm):
+            """ Test charfield """
+            charfield = fields.CharField(accesses={'jedi': REQUIRED})
+
+        formidable = TestCharField.to_formidable(label='label')
+        schema = ContextFormSerializer(instance=formidable, context={
+            'role': 'jedi'
+        }).data
+        form = get_dynamic_form_class_from_schema(schema)()
+        self.assertIn('charfield', form.fields)
+        charfield = form.fields['charfield']
+        self.assertEqual(type(charfield), forms.CharField)
+        self.assertTrue(charfield.required)
+
+    def test_paragraph_field(self):
+        class TestParagraphField(FormidableForm):
+            """ Test Paraprah """
+            paragraph = fields.CharField(widget=widgets.Textarea)
+
+        formidable = TestParagraphField.to_formidable(label='label')
+        schema = ContextFormSerializer(instance=formidable, context={
+            'role': 'jedi'
+        }).data
+        form = get_dynamic_form_class_from_schema(schema)()
+        self.assertIn('paragraph', form.fields)
+        charfield = form.fields['paragraph']
+        self.assertEqual(type(charfield), forms.CharField)
+        self.assertEqual(type(charfield.widget), forms.Textarea)
+        self.assertFalse(charfield.required)

--- a/demo/tests/test_form_from_schema.py
+++ b/demo/tests/test_form_from_schema.py
@@ -87,3 +87,18 @@ class TestFormFromSchema(TestCase):
         self.assertIn('email', form.fields)
         email = form.fields['email']
         self.assertEqual(type(email), forms.EmailField)
+
+    def test_integer_field(self):
+        class TestintegerField(FormidableForm):
+            """ Test integer """
+            integer = fields.IntegerField()
+
+        formidable = TestintegerField.to_formidable(label='label')
+
+        schema = ContextFormSerializer(instance=formidable, context={
+            'role': 'jedi'
+        }).data
+        form = get_dynamic_form_class_from_schema(schema)()
+        self.assertIn('integer', form.fields)
+        integer = form.fields['integer']
+        self.assertEqual(type(integer), forms.IntegerField)

--- a/demo/tests/test_form_from_schema.py
+++ b/demo/tests/test_form_from_schema.py
@@ -102,3 +102,18 @@ class TestFormFromSchema(TestCase):
         self.assertIn('integer', form.fields)
         integer = form.fields['integer']
         self.assertEqual(type(integer), forms.IntegerField)
+
+    def test_file_field(self):
+        class TestfileField(FormidableForm):
+            """ Test file """
+            file_ = fields.FileField()
+
+        formidable = TestfileField.to_formidable(label='label')
+
+        schema = ContextFormSerializer(instance=formidable, context={
+            'role': 'jedi'
+        }).data
+        form = get_dynamic_form_class_from_schema(schema)()
+        self.assertIn('file_', form.fields)
+        file_ = form.fields['file_']
+        self.assertEqual(type(file_), forms.FileField)

--- a/demo/tests/test_form_from_schema.py
+++ b/demo/tests/test_form_from_schema.py
@@ -7,7 +7,9 @@ from formidable.constants import REQUIRED
 from formidable.forms import (
     FormidableForm, fields, get_dynamic_form_class_from_schema
 )
-from formidable.forms import widgets
+from formidable.forms import (
+    field_builder, field_builder_from_schema, widgets
+)
 from formidable.forms.validations.presets import (
     ConfirmationPresets
 )
@@ -15,6 +17,7 @@ from formidable.models import PresetArg
 from formidable.validators import (
     GTEValidator, MinLengthValidator, AgeAboveValidator
 )
+
 from formidable.serializers.forms import ContextFormSerializer
 
 
@@ -382,3 +385,13 @@ class TestFormFromSchema(TestCase):
             'email': 'test@test.tld', 'email_confirm': 'test@test.tld'
         })
         self.assertTrue(form.is_valid())
+
+    def test_mapping(self):
+        """
+        Simple test to make sure that every widget is implemented.
+
+        """
+        self.assertEqual(
+            set(field_builder.FormFieldFactory.field_map),
+            set(field_builder_from_schema.FormFieldFactory.field_map)
+        )

--- a/demo/tests/test_form_from_schema.py
+++ b/demo/tests/test_form_from_schema.py
@@ -117,3 +117,18 @@ class TestFormFromSchema(TestCase):
         self.assertIn('file_', form.fields)
         file_ = form.fields['file_']
         self.assertEqual(type(file_), forms.FileField)
+
+    def test_date_field(self):
+        class TestdateField(FormidableForm):
+            """ Test date """
+            date = fields.DateField()
+
+        formidable = TestdateField.to_formidable(label='label')
+
+        schema = ContextFormSerializer(instance=formidable, context={
+            'role': 'jedi'
+        }).data
+        form = get_dynamic_form_class_from_schema(schema)()
+        self.assertIn('date', form.fields)
+        date = form.fields['date']
+        self.assertEqual(type(date), forms.DateField)

--- a/demo/tests/test_form_from_schema.py
+++ b/demo/tests/test_form_from_schema.py
@@ -29,7 +29,8 @@ class TestFormFromSchema(TestCase):
         schema = ContextFormSerializer(instance=formidable, context={
             'role': 'jedi'
         }).data
-        form = get_dynamic_form_class_from_schema(schema)()
+        form_class = get_dynamic_form_class_from_schema(schema)
+        form = form_class()
         self.assertIn('charfield', form.fields)
         charfield = form.fields['charfield']
         self.assertEqual(type(charfield), forms.CharField)
@@ -44,7 +45,8 @@ class TestFormFromSchema(TestCase):
         schema = ContextFormSerializer(instance=formidable, context={
             'role': 'jedi'
         }).data
-        form = get_dynamic_form_class_from_schema(schema)()
+        form_class = get_dynamic_form_class_from_schema(schema)
+        form = form_class()
         self.assertIn('charfield', form.fields)
         charfield = form.fields['charfield']
         self.assertEqual(type(charfield), forms.CharField)
@@ -59,7 +61,8 @@ class TestFormFromSchema(TestCase):
         schema = ContextFormSerializer(instance=formidable, context={
             'role': 'jedi'
         }).data
-        form = get_dynamic_form_class_from_schema(schema)()
+        form_class = get_dynamic_form_class_from_schema(schema)
+        form = form_class()
         self.assertIn('paragraph', form.fields)
         charfield = form.fields['paragraph']
         self.assertEqual(type(charfield), forms.CharField)
@@ -76,7 +79,8 @@ class TestFormFromSchema(TestCase):
         schema = ContextFormSerializer(instance=formidable, context={
             'role': 'jedi'
         }).data
-        form = get_dynamic_form_class_from_schema(schema)()
+        form_class = get_dynamic_form_class_from_schema(schema)
+        form = form_class()
         self.assertIn('checkbox', form.fields)
         checkbox = form.fields['checkbox']
         self.assertEqual(type(checkbox), forms.BooleanField)
@@ -91,7 +95,8 @@ class TestFormFromSchema(TestCase):
         schema = ContextFormSerializer(instance=formidable, context={
             'role': 'jedi'
         }).data
-        form = get_dynamic_form_class_from_schema(schema)()
+        form_class = get_dynamic_form_class_from_schema(schema)
+        form = form_class()
         self.assertIn('email', form.fields)
         email = form.fields['email']
         self.assertEqual(type(email), forms.EmailField)
@@ -106,7 +111,8 @@ class TestFormFromSchema(TestCase):
         schema = ContextFormSerializer(instance=formidable, context={
             'role': 'jedi'
         }).data
-        form = get_dynamic_form_class_from_schema(schema)()
+        form_class = get_dynamic_form_class_from_schema(schema)
+        form = form_class()
         self.assertIn('integer', form.fields)
         integer = form.fields['integer']
         self.assertEqual(type(integer), forms.IntegerField)
@@ -121,7 +127,8 @@ class TestFormFromSchema(TestCase):
         schema = ContextFormSerializer(instance=formidable, context={
             'role': 'jedi'
         }).data
-        form = get_dynamic_form_class_from_schema(schema)()
+        form_class = get_dynamic_form_class_from_schema(schema)
+        form = form_class()
         self.assertIn('file_', form.fields)
         file_ = form.fields['file_']
         self.assertEqual(type(file_), forms.FileField)
@@ -136,7 +143,8 @@ class TestFormFromSchema(TestCase):
         schema = ContextFormSerializer(instance=formidable, context={
             'role': 'jedi'
         }).data
-        form = get_dynamic_form_class_from_schema(schema)()
+        form_class = get_dynamic_form_class_from_schema(schema)
+        form = form_class()
         self.assertIn('date', form.fields)
         date = form.fields['date']
         self.assertEqual(type(date), forms.DateField)
@@ -152,7 +160,8 @@ class TestFormFromSchema(TestCase):
         schema = ContextFormSerializer(instance=formidable, context={
             'role': 'jedi'
         }).data
-        form = get_dynamic_form_class_from_schema(schema)()
+        form_class = get_dynamic_form_class_from_schema(schema)
+        form = form_class()
         self.assertIn('weapon', form.fields)
         self.assertEqual(type(form.fields['weapon']), forms.ChoiceField)
         self.assertEqual(type(form.fields['weapon'].widget), forms.Select)
@@ -170,7 +179,8 @@ class TestFormFromSchema(TestCase):
         schema = ContextFormSerializer(instance=formidable, context={
             'role': 'jedi'
         }).data
-        form = get_dynamic_form_class_from_schema(schema)()
+        form_class = get_dynamic_form_class_from_schema(schema)
+        form = form_class()
         self.assertIn('weapon', form.fields)
         self.assertEqual(
             type(form.fields['weapon']), forms.MultipleChoiceField

--- a/demo/tests/test_form_from_schema.py
+++ b/demo/tests/test_form_from_schema.py
@@ -179,6 +179,7 @@ class TestFormFromSchema(TestCase):
         schema = ContextFormSerializer(instance=formidable, context={
             'role': 'jedi'
         }).data
+
         form_class = get_dynamic_form_class_from_schema(schema)
         form = form_class()
         self.assertIn('weapon', form.fields)
@@ -190,6 +191,63 @@ class TestFormFromSchema(TestCase):
         )
         self.assertIn(('gun', 'Eagles'), form.fields['weapon'].choices)
         self.assertIn(('sword', 'Excalibur'), form.fields['weapon'].choices)
+
+    def test_radio_field(self):
+        class TestRadioField(FormidableForm):
+            radioinput = fields.ChoiceField(
+                widget=widgets.RadioSelect,
+                choices=(('yes', 'Yes'), ('no', 'No')),
+            )
+
+        formidable = TestRadioField.to_formidable(label='form-with-radio')
+        schema = ContextFormSerializer(instance=formidable, context={
+            'role': 'jedi'
+        }).data
+
+        form_class = get_dynamic_form_class_from_schema(schema)
+        form = form_class()
+
+        self.assertIn('radioinput', form.fields)
+        self.assertEqual(
+            type(form.fields['radioinput']), forms.ChoiceField
+        )
+        self.assertEqual(
+            type(form.fields['radioinput'].widget), forms.RadioSelect
+        )
+        self.assertIn(('yes', 'Yes'), form.fields['radioinput'].choices)
+        self.assertIn(('no', 'No'), form.fields['radioinput'].choices)
+
+    def test_checkbox_multiple_field(self):
+
+        choices = (
+            ('BELGIUM', 'Chouffe'), ('GERMANY', 'Paulaner'),
+            ('FRANCE', 'Antidote')
+        )
+
+        class TestCheckboxesField(FormidableForm):
+
+            checkboxesinput = fields.MultipleChoiceField(
+                widget=widgets.CheckboxSelectMultiple,
+                choices=choices,
+            )
+
+        formidable = TestCheckboxesField.to_formidable(label='checkboxes')
+        schema = ContextFormSerializer(instance=formidable, context={
+            'role': 'jedi'
+        }).data
+
+        form_class = get_dynamic_form_class_from_schema(schema)
+        form = form_class()
+
+        self.assertIn('checkboxesinput', form.fields)
+
+        checkboxes = form.fields['checkboxesinput']
+
+        self.assertEqual(type(checkboxes), forms.MultipleChoiceField)
+        self.assertEqual(type(checkboxes.widget), forms.CheckboxSelectMultiple)
+        self.assertIn(('BELGIUM', 'Chouffe'), checkboxes.choices)
+        self.assertIn(('FRANCE', 'Antidote'), checkboxes.choices)
+        self.assertIn(('GERMANY', 'Paulaner'), checkboxes.choices)
 
     @freeze_time('2021-01-01')
     def test_date_field_with_validation(self):

--- a/demo/tests/test_form_from_schema.py
+++ b/demo/tests/test_form_from_schema.py
@@ -141,6 +141,46 @@ class TestFormFromSchema(TestCase):
         date = form.fields['date']
         self.assertEqual(type(date), forms.DateField)
 
+    def test_dropdown_field(self):
+        class WithDropdown(FormidableForm):
+            weapon = fields.ChoiceField(
+                widget=widgets.Select,
+                choices=(('gun', 'Eagles'), ('sword', 'Excalibur'))
+            )
+
+        formidable = WithDropdown.to_formidable(label='dropdown')
+        schema = ContextFormSerializer(instance=formidable, context={
+            'role': 'jedi'
+        }).data
+        form = get_dynamic_form_class_from_schema(schema)()
+        self.assertIn('weapon', form.fields)
+        self.assertEqual(type(form.fields['weapon']), forms.ChoiceField)
+        self.assertEqual(type(form.fields['weapon'].widget), forms.Select)
+        self.assertIn(('gun', 'Eagles'), form.fields['weapon'].choices)
+        self.assertIn(('sword', 'Excalibur'), form.fields['weapon'].choices)
+
+    def test_dropdown_multiple(self):
+        class WithDropdown(FormidableForm):
+            weapon = fields.ChoiceField(
+                widget=widgets.SelectMultiple,
+                choices=(('gun', 'Eagles'), ('sword', 'Excalibur'))
+            )
+
+        formidable = WithDropdown.to_formidable(label='dropdown')
+        schema = ContextFormSerializer(instance=formidable, context={
+            'role': 'jedi'
+        }).data
+        form = get_dynamic_form_class_from_schema(schema)()
+        self.assertIn('weapon', form.fields)
+        self.assertEqual(
+            type(form.fields['weapon']), forms.MultipleChoiceField
+        )
+        self.assertEqual(
+            type(form.fields['weapon'].widget), forms.SelectMultiple
+        )
+        self.assertIn(('gun', 'Eagles'), form.fields['weapon'].choices)
+        self.assertIn(('sword', 'Excalibur'), form.fields['weapon'].choices)
+
     @freeze_time('2021-01-01')
     def test_date_field_with_validation(self):
         class TestdateField(FormidableForm):

--- a/demo/tests/test_form_from_schema.py
+++ b/demo/tests/test_form_from_schema.py
@@ -72,3 +72,18 @@ class TestFormFromSchema(TestCase):
         self.assertIn('checkbox', form.fields)
         checkbox = form.fields['checkbox']
         self.assertEqual(type(checkbox), forms.BooleanField)
+
+    def test_email_field(self):
+        class TestemailField(FormidableForm):
+            """ Test email """
+            email = fields.EmailField()
+
+        formidable = TestemailField.to_formidable(label='label')
+
+        schema = ContextFormSerializer(instance=formidable, context={
+            'role': 'jedi'
+        }).data
+        form = get_dynamic_form_class_from_schema(schema)()
+        self.assertIn('email', form.fields)
+        email = form.fields['email']
+        self.assertEqual(type(email), forms.EmailField)

--- a/demo/tests/test_form_from_schema.py
+++ b/demo/tests/test_form_from_schema.py
@@ -57,3 +57,18 @@ class TestFormFromSchema(TestCase):
         self.assertEqual(type(charfield), forms.CharField)
         self.assertEqual(type(charfield.widget), forms.Textarea)
         self.assertFalse(charfield.required)
+
+    def test_checkbox_field(self):
+        class TestCheckBoxField(FormidableForm):
+            """ Test checkbox """
+            checkbox = fields.BooleanField()
+
+        formidable = TestCheckBoxField.to_formidable(label='label')
+
+        schema = ContextFormSerializer(instance=formidable, context={
+            'role': 'jedi'
+        }).data
+        form = get_dynamic_form_class_from_schema(schema)()
+        self.assertIn('checkbox', form.fields)
+        checkbox = form.fields['checkbox']
+        self.assertEqual(type(checkbox), forms.BooleanField)

--- a/demo/tests/test_form_from_schema.py
+++ b/demo/tests/test_form_from_schema.py
@@ -91,6 +91,50 @@ class TestFormFromSchema(TestCase):
         self.assertEqual(type(helptext.widget), widgets.HelpTextWidget)
         self.assertFalse(helptext.required)
 
+    def test_separator(self):
+        class TestSeparatorField(FormidableForm):
+            """
+            Test for separator
+
+            """
+            separator = fields.SeparatorField()
+
+        formidable = TestSeparatorField.to_formidable(label='label')
+        schema = ContextFormSerializer(instance=formidable, context={
+            'role': 'jedi'
+        }).data
+
+        form_class = get_dynamic_form_class_from_schema(schema)
+        form = form_class()
+
+        self.assertIn('separator', form.fields)
+        separator = form.fields['separator']
+        self.assertEqual(type(separator), fields.SeparatorField)
+        self.assertEqual(type(separator.widget), widgets.SeparatorWidget)
+        self.assertFalse(separator.required)
+
+    def test_title(self):
+        class TestTitleField(FormidableForm):
+            """
+            Test for separator
+
+            """
+            title = fields.TitleField()
+
+        formidable = TestTitleField.to_formidable(label='label')
+        schema = ContextFormSerializer(instance=formidable, context={
+            'role': 'jedi'
+        }).data
+
+        form_class = get_dynamic_form_class_from_schema(schema)
+        form = form_class()
+
+        self.assertIn('title', form.fields)
+        title = form.fields['title']
+        self.assertEqual(type(title), fields.TitleField)
+        self.assertEqual(type(title.widget), widgets.TitleWidget)
+        self.assertFalse(title.required)
+
     def test_checkbox_field(self):
         class TestCheckBoxField(FormidableForm):
             """ Test checkbox """

--- a/demo/tests/test_from_form.py
+++ b/demo/tests/test_from_form.py
@@ -417,6 +417,7 @@ class TestFromDjangoForm(TestCase):
 
         initial_count = Formidable.objects.count()
         form = MyForm.to_formidable(label='form-with-radios')
+
         self.assertEquals(initial_count + 1, Formidable.objects.count())
         self.assertTrue(form.pk)
         self.assertEquals(form.fields.count(), 1)

--- a/formidable/forms/__init__.py
+++ b/formidable/forms/__init__.py
@@ -67,7 +67,7 @@ def get_dynamic_form_class_from_schema(schema, field_factory=None):
     for field in schema['fields']:
         attrs[field['slug']] = field_factory.produce(field)
 
-    attrs['rules'] = []
+    attrs['rules'] = presets_register.build_rules_from_schema(schema)
     klass = type(str('DynamicForm'), (BaseDynamicForm,), attrs)
     klass.__doc__ = doc
     return klass

--- a/formidable/forms/__init__.py
+++ b/formidable/forms/__init__.py
@@ -67,6 +67,7 @@ def get_dynamic_form_class_from_schema(schema, field_factory=None):
     for field in schema['fields']:
         attrs[field['slug']] = field_factory.produce(field)
 
+    attrs['rules'] = []
     klass = type(str('DynamicForm'), (BaseDynamicForm,), attrs)
     klass.__doc__ = doc
     return klass

--- a/formidable/forms/field_builder.py
+++ b/formidable/forms/field_builder.py
@@ -99,8 +99,14 @@ class FieldBuilder(object):
         return list(self.gen_validators())
 
     def gen_validators(self):
-        for validation in self.field.validations.all():
+        for validation in self.get_validations():
             yield self.validator_factory.produce(validation)
+
+    def get_validations(self):
+        """
+        return iterator over field validation
+        """
+        return self.field.validations.all()
 
 
 class FileFieldBuilder(FieldBuilder):

--- a/formidable/forms/field_builder.py
+++ b/formidable/forms/field_builder.py
@@ -23,9 +23,16 @@ class FieldBuilder(object):
         self.validator_factory = self.validator_factory_class()
 
     def build(self, role=None):
-        self.access = self.field.accesses.all()[0] if role else None
+        self.access = self.get_accesses(role)
         field_class = self.get_field_class()
         return field_class(**self.get_field_kwargs())
+
+    def get_accesses(self, role):
+        if role:
+            # The role is previously "prefetch" in order to avoid database
+            # hit, we don't use a get() method in queryset.
+            return self.field.accesses.all()[0]
+        return None
 
     def get_field_class(self):
         return self.field_class

--- a/formidable/forms/field_builder.py
+++ b/formidable/forms/field_builder.py
@@ -220,8 +220,12 @@ class FormFieldFactory(object):
         :class:`django.forms.Field` instance according to the type_id,
         validations and rules.
         """
-        builder = self.map[field.type_id](field)
+        type_id = self.get_type_id(field)
+        builder = self.map[type_id](field)
         return builder.build(role)
+
+    def get_type_id(self, field):
+        return field.type_id
 
 
 form_field_factory = FormFieldFactory()

--- a/formidable/forms/field_builder_from_schema.py
+++ b/formidable/forms/field_builder_from_schema.py
@@ -53,6 +53,10 @@ class IntegerFieldBuilder(FieldBuilder):
     field_class = forms.IntegerField
 
 
+class FileFieldBuilder(FieldBuilder):
+    field_class = forms.FileField
+
+
 class FormFieldFactory(FF):
 
     field_map = {
@@ -61,6 +65,7 @@ class FormFieldFactory(FF):
         'checkbox': CheckboxFieldBuilder,
         'email': EmailFieldBuilder,
         'number': IntegerFieldBuilder,
+        'file': FileFieldBuilder,
     }
 
     def get_type_id(self, field):

--- a/formidable/forms/field_builder_from_schema.py
+++ b/formidable/forms/field_builder_from_schema.py
@@ -49,6 +49,10 @@ class EmailFieldBuilder(FieldBuilder):
     field_class = forms.EmailField
 
 
+class IntegerFieldBuilder(FieldBuilder):
+    field_class = forms.IntegerField
+
+
 class FormFieldFactory(FF):
 
     field_map = {
@@ -56,6 +60,7 @@ class FormFieldFactory(FF):
         'paragraph': ParagraphFieldBuilder,
         'checkbox': CheckboxFieldBuilder,
         'email': EmailFieldBuilder,
+        'number': IntegerFieldBuilder,
     }
 
     def get_type_id(self, field):

--- a/formidable/forms/field_builder_from_schema.py
+++ b/formidable/forms/field_builder_from_schema.py
@@ -3,26 +3,28 @@ from django import forms
 
 from formidable.forms import fields
 from formidable.forms.field_builder import (
-    FieldBuilder as FB, FormFieldFactory as FF
+    FieldBuilder as BaseFieldBuilder,
+    FormFieldFactory as BaseFormFieldFactory
 )
 from formidable.validators import (
-    DateValidatorFactory as DVF, ValidatorFactory as VF
+    DateValidatorFactory as BaseDateValidatorFactory,
+    ValidatorFactory as BaseValidatorFactory
 )
 
 
-class ValidatorFactory(VF):
+class ValidatorFactory(BaseValidatorFactory):
 
     def extract_validation_attribute(self, validation):
         return validation['type'], validation['message'], validation['value']
 
 
-class DateValidatorFactory(DVF):
+class DateValidatorFactory(BaseDateValidatorFactory):
 
     def extract_validation_attribute(self, validation):
         return validation['type'], validation['message'], validation['value']
 
 
-class FieldBuilder(FB):
+class FieldBuilder(BaseFieldBuilder):
 
     field_class = forms.CharField
     widget_class = None
@@ -79,22 +81,27 @@ class ParagraphFieldBuilder(FieldBuilder):
 
 
 class CheckboxFieldBuilder(FieldBuilder):
+
     field_class = forms.BooleanField
 
 
 class EmailFieldBuilder(FieldBuilder):
+
     field_class = forms.EmailField
 
 
 class IntegerFieldBuilder(FieldBuilder):
+
     field_class = forms.IntegerField
 
 
 class FileFieldBuilder(FieldBuilder):
+
     field_class = forms.FileField
 
 
 class DateFieldBuilder(FieldBuilder):
+
     field_class = forms.DateField
     validator_factory_class = DateValidatorFactory
 
@@ -139,7 +146,7 @@ class CheckboxesFieldBuilder(ChoiceFieldBuilder):
     widget_class = forms.CheckboxSelectMultiple
 
 
-class FormFieldFactory(FF):
+class FormFieldFactory(BaseFormFieldFactory):
 
     field_map = {
         'text': TextFieldBuilder,

--- a/formidable/forms/field_builder_from_schema.py
+++ b/formidable/forms/field_builder_from_schema.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from django import forms
+
+from formidable.forms.field_builder import (
+    FieldBuilder as FB, FormFieldFactory as FF
+)
+
+
+class FieldBuilder(FB):
+
+    field_class = forms.CharField
+    widget_class = None
+
+    def get_required(self):
+        return self.field['required']
+
+    def get_disabled(self):
+        return self.field['disabled']
+
+    def get_label(self):
+        return self.field['label']
+
+    def get_help_text(self):
+        return self.field['description']
+
+    def get_validators(self):
+        return []
+
+
+class TextFieldBuilder(FieldBuilder):
+
+    widget_class = forms.TextInput
+
+
+class ParagraphFieldBuilder(FieldBuilder):
+
+    widget_class = forms.Textarea
+
+
+class FormFieldFactory(FF):
+
+    field_map = {
+        'text': TextFieldBuilder,
+        'paragraph': ParagraphFieldBuilder,
+    }
+
+    def get_type_id(self, field):
+        return field['type_id']

--- a/formidable/forms/field_builder_from_schema.py
+++ b/formidable/forms/field_builder_from_schema.py
@@ -4,10 +4,18 @@ from django import forms
 from formidable.forms.field_builder import (
     FieldBuilder as FB, FormFieldFactory as FF
 )
-from formidable.validators import ValidatorFactory as VF
+from formidable.validators import (
+    DateValidatorFactory as DVF, ValidatorFactory as VF
+)
 
 
 class ValidatorFactory(VF):
+
+    def extract_validation_attribute(self, validation):
+        return validation['type'], validation['message'], validation['value']
+
+
+class DateValidatorFactory(DVF):
 
     def extract_validation_attribute(self, validation):
         return validation['type'], validation['message'], validation['value']
@@ -67,6 +75,7 @@ class FileFieldBuilder(FieldBuilder):
 
 class DateFieldBuilder(FieldBuilder):
     field_class = forms.DateField
+    validator_factory_class = DateValidatorFactory
 
 
 class FormFieldFactory(FF):

--- a/formidable/forms/field_builder_from_schema.py
+++ b/formidable/forms/field_builder_from_schema.py
@@ -57,6 +57,10 @@ class FileFieldBuilder(FieldBuilder):
     field_class = forms.FileField
 
 
+class DateFieldBuilder(FieldBuilder):
+    field_class = forms.DateField
+
+
 class FormFieldFactory(FF):
 
     field_map = {
@@ -66,6 +70,7 @@ class FormFieldFactory(FF):
         'email': EmailFieldBuilder,
         'number': IntegerFieldBuilder,
         'file': FileFieldBuilder,
+        'date': DateFieldBuilder,
     }
 
     def get_type_id(self, field):

--- a/formidable/forms/field_builder_from_schema.py
+++ b/formidable/forms/field_builder_from_schema.py
@@ -45,12 +45,17 @@ class CheckboxFieldBuilder(FieldBuilder):
     field_class = forms.BooleanField
 
 
+class EmailFieldBuilder(FieldBuilder):
+    field_class = forms.EmailField
+
+
 class FormFieldFactory(FF):
 
     field_map = {
         'text': TextFieldBuilder,
         'paragraph': ParagraphFieldBuilder,
         'checkbox': CheckboxFieldBuilder,
+        'email': EmailFieldBuilder,
     }
 
     def get_type_id(self, field):

--- a/formidable/forms/field_builder_from_schema.py
+++ b/formidable/forms/field_builder_from_schema.py
@@ -159,6 +159,7 @@ class FormFieldFactory(BaseFormFieldFactory):
         'date': DateFieldBuilder,
         'dropdown': DropdownFieldBuilder,
         'radios': RadioFieldBuilder,
+        'radios_buttons': RadioFieldBuilder,
         'help_text': HelpTextBuilder,
         'separator': SeparatorBuilder,
         'title': TitleFielBuilder,

--- a/formidable/forms/field_builder_from_schema.py
+++ b/formidable/forms/field_builder_from_schema.py
@@ -41,11 +41,16 @@ class ParagraphFieldBuilder(FieldBuilder):
     widget_class = forms.Textarea
 
 
+class CheckboxFieldBuilder(FieldBuilder):
+    field_class = forms.BooleanField
+
+
 class FormFieldFactory(FF):
 
     field_map = {
         'text': TextFieldBuilder,
         'paragraph': ParagraphFieldBuilder,
+        'checkbox': CheckboxFieldBuilder,
     }
 
     def get_type_id(self, field):

--- a/formidable/forms/field_builder_from_schema.py
+++ b/formidable/forms/field_builder_from_schema.py
@@ -107,18 +107,30 @@ class DropdownFieldBuilder(ChoiceFieldBuilder):
         return super(DropdownFieldBuilder, self).get_widget_class()
 
 
+class RadioFieldBuilder(ChoiceFieldBuilder):
+
+    widget_class = forms.RadioSelect
+
+
+class CheckboxesFieldBuilder(ChoiceFieldBuilder):
+
+    field_class = forms.MultipleChoiceField
+    widget_class = forms.CheckboxSelectMultiple
+
+
 class FormFieldFactory(FF):
 
     field_map = {
         'text': TextFieldBuilder,
         'paragraph': ParagraphFieldBuilder,
         'checkbox': CheckboxFieldBuilder,
+        'checkboxes': CheckboxesFieldBuilder,
         'email': EmailFieldBuilder,
         'number': IntegerFieldBuilder,
         'file': FileFieldBuilder,
         'date': DateFieldBuilder,
         'dropdown': DropdownFieldBuilder,
-
+        'radios': RadioFieldBuilder,
     }
 
     def get_type_id(self, field):

--- a/formidable/forms/field_builder_from_schema.py
+++ b/formidable/forms/field_builder_from_schema.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from django import forms
 
+from formidable.forms import fields
 from formidable.forms.field_builder import (
     FieldBuilder as FB, FormFieldFactory as FF
 )
@@ -45,6 +46,16 @@ class FieldBuilder(FB):
     def get_accesses(self, role):
         # No need to compute accesses, the schema is already contextualized.
         return None
+
+
+class HelpTextBuilder(FieldBuilder):
+
+    field_class = fields.HelpTextField
+
+    def get_field_kwargs(self):
+        kwargs = super(HelpTextBuilder, self).get_field_kwargs()
+        kwargs['text'] = kwargs.pop('help_text')
+        return kwargs
 
 
 class TextFieldBuilder(FieldBuilder):
@@ -131,6 +142,7 @@ class FormFieldFactory(FF):
         'date': DateFieldBuilder,
         'dropdown': DropdownFieldBuilder,
         'radios': RadioFieldBuilder,
+        'help_text': HelpTextBuilder,
     }
 
     def get_type_id(self, field):

--- a/formidable/forms/field_builder_from_schema.py
+++ b/formidable/forms/field_builder_from_schema.py
@@ -88,10 +88,8 @@ class ChoiceFieldBuilder(FieldBuilder):
         return kwargs
 
     def get_choices(self):
-        choices = []
         for item in self.field.get('items', []):
-            choices.append((item['value'], item['label']))
-        return choices
+            yield (item['value'], item['label'])
 
 
 class DropdownFieldBuilder(ChoiceFieldBuilder):

--- a/formidable/forms/field_builder_from_schema.py
+++ b/formidable/forms/field_builder_from_schema.py
@@ -58,6 +58,16 @@ class HelpTextBuilder(FieldBuilder):
         return kwargs
 
 
+class SeparatorBuilder(FieldBuilder):
+
+    field_class = fields.SeparatorField
+
+
+class TitleFielBuilder(FieldBuilder):
+
+    field_class = fields.TitleField
+
+
 class TextFieldBuilder(FieldBuilder):
 
     widget_class = forms.TextInput
@@ -143,6 +153,8 @@ class FormFieldFactory(FF):
         'dropdown': DropdownFieldBuilder,
         'radios': RadioFieldBuilder,
         'help_text': HelpTextBuilder,
+        'separator': SeparatorBuilder,
+        'title': TitleFielBuilder,
     }
 
     def get_type_id(self, field):

--- a/formidable/forms/field_builder_from_schema.py
+++ b/formidable/forms/field_builder_from_schema.py
@@ -26,6 +26,10 @@ class FieldBuilder(FB):
     def get_validators(self):
         return []
 
+    def get_accesses(self, role):
+        # No need to compute accesses, the schema is already contextualized.
+        return None
+
 
 class TextFieldBuilder(FieldBuilder):
 

--- a/formidable/forms/field_builder_from_schema.py
+++ b/formidable/forms/field_builder_from_schema.py
@@ -4,12 +4,20 @@ from django import forms
 from formidable.forms.field_builder import (
     FieldBuilder as FB, FormFieldFactory as FF
 )
+from formidable.validators import ValidatorFactory as VF
+
+
+class ValidatorFactory(VF):
+
+    def extract_validation_attribute(self, validation):
+        return validation['type'], validation['message'], validation['value']
 
 
 class FieldBuilder(FB):
 
     field_class = forms.CharField
     widget_class = None
+    validator_factory_class = ValidatorFactory
 
     def get_required(self):
         return self.field['required']
@@ -23,8 +31,8 @@ class FieldBuilder(FB):
     def get_help_text(self):
         return self.field['description']
 
-    def get_validators(self):
-        return []
+    def get_validations(self):
+        return self.field['validations']
 
     def get_accesses(self, role):
         # No need to compute accesses, the schema is already contextualized.

--- a/formidable/forms/field_builder_from_schema.py
+++ b/formidable/forms/field_builder_from_schema.py
@@ -78,6 +78,37 @@ class DateFieldBuilder(FieldBuilder):
     validator_factory_class = DateValidatorFactory
 
 
+class ChoiceFieldBuilder(FieldBuilder):
+
+    field_class = forms.ChoiceField
+
+    def get_field_kwargs(self):
+        kwargs = super(ChoiceFieldBuilder, self).get_field_kwargs()
+        kwargs['choices'] = self.get_choices()
+        return kwargs
+
+    def get_choices(self):
+        choices = []
+        for item in self.field.get('items', []):
+            choices.append((item['value'], item['label']))
+        return choices
+
+
+class DropdownFieldBuilder(ChoiceFieldBuilder):
+
+    widget_class = forms.Select
+
+    def get_field_class(self):
+        if self.field['multiple']:
+            return forms.MultipleChoiceField
+        return super(DropdownFieldBuilder, self).get_field_class()
+
+    def get_widget_class(self):
+        if self.field['multiple']:
+            return forms.SelectMultiple
+        return super(DropdownFieldBuilder, self).get_widget_class()
+
+
 class FormFieldFactory(FF):
 
     field_map = {
@@ -88,6 +119,8 @@ class FormFieldFactory(FF):
         'number': IntegerFieldBuilder,
         'file': FileFieldBuilder,
         'date': DateFieldBuilder,
+        'dropdown': DropdownFieldBuilder,
+
     }
 
     def get_type_id(self, field):

--- a/formidable/forms/validations/presets.py
+++ b/formidable/forms/validations/presets.py
@@ -11,7 +11,7 @@ from django.utils.translation import ugettext_lazy as _
 
 import six
 
-from formidable.models import Preset
+from formidable.models import Preset, PresetArg
 
 
 class PresetsRegister(dict):
@@ -29,6 +29,23 @@ class PresetsRegister(dict):
                 # preset defined on a field that is filtered (current role
                 # does not match the accesses)
                 pass
+
+    def build_rules_from_schema(self, schema):
+        rules = []
+        for preset in schema.get('presets', []):
+            klass = self[preset['preset_id']]
+            arguments = self.get_arguments_from_schema(preset.get(
+                'arguments', []
+            ))
+            rules.append(klass(arguments, message=preset['message']))
+
+        return rules
+
+    def get_arguments_from_schema(self, arguments):
+        args = []
+        for argument in arguments:
+            args.append(PresetArg(**argument))
+        return args
 
 
 presets_register = PresetsRegister()

--- a/formidable/validators.py
+++ b/formidable/validators.py
@@ -235,9 +235,15 @@ class ValidatorFactory(object):
         return NEQValidator(value, message)
 
     def produce(self, validation):
-        meth = self.maps[validation.type]
-        msg = validation.message or None
-        return meth(self, validation.value, msg)
+        type_, msg, value = self.extract_validation_attribute(validation)
+        meth = self.maps[type_]
+        return meth(self, value, msg)
+
+    def extract_validation_attribute(self, validation):
+        """
+        Return the tuple of validation type, validation msg, validation value
+        """
+        return validation.type, validation.message or None, validation.value
 
 
 class DateValidatorFactory(ValidatorFactory):


### PR DESCRIPTION
### Use case

When the contextualized schema is already stored in database (First step to reach the versioning directly in formidable) generate the associated django form class.

### Used with Contextualized definition

```python
schema = ContextFormSerializer(instance=formidable, context={
    'role': 'jedi'
}).data

form_class = get_dynamic_form_class_from_schema(schema)
form = form_class(data={'first_name': 'Obiwan', 'last_name': 'Kenobi'})
form.is_valid()
```

### Remaining Standard Fields to Handle

- [x] Radio
- [ ] Radio Button (I'm really asking if we need to handle it in formidable, because it's not a standard input, it's specific needed for peopleask)
- [x] Checkboxes

### Remaining Format Field to handle

- [x] Help Text
- [x] Separator Field
- [x] Title