### PR TITLE
ignore the .crowdin directory for the flake8 tox job.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ ChangeLog
 master (unreleased)
 ===================
 
-- Nothing here yet.
+- Fix: excluding the `.crowdin` directory in the flake8 tox job (#179).
 
 Release 0.7.0 (2016-02-15)
 ==========================

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,9 @@ changedir =
     {toxinidir}
 deps = flake8
 commands =
-    flake8 .
+    ; excluding git and cache dirs, tox-related dirs (default)
+    ; excluding .crowdin directory (used for i18n processing)
+    flake8 --exclude=.git,__pycache__,.tox,.crowdin
 
 [testenv:check-python-imports]
 changedir =


### PR DESCRIPTION
refs #179