### PR TITLE
fix setup.cfg parsing with python3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,8 @@ known_first_party = formidable
 sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 
 combine_as_imports = true
-multi_line_output = 5 ; Hanging Grid Grouped
+; 5 = Hanging Grid Grouped
+multi_line_output = 5
 not_skip = __init__.py
 skip = migrations, settings
 line_length = 80


### PR DESCRIPTION
Python3's ConfigParser does not support inline comments in config files
The way it was parsed caused isort to crash because of a bad value for
`multi_line_output`