### PR TITLE
[ci] Split tox jobs into CircleCI configuration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Release 0.7.1 (2017-02-22)
 * add presets to ContextFormSerializer (#176). Add presets creation directly in a FormidableForm declaration. Rework tests with presets.
 * Fix: error message for preset validation is not the one specified (#185)
 * Improve isort management in tox file (#147)
+* [ci] Split tox jobs into CircleCI configuration (#189)
 
 Release 0.7.0 (2017-02-15)
 ==========================

--- a/circle.yml
+++ b/circle.yml
@@ -8,4 +8,7 @@ dependencies:
 
 test:
     override:
-        - tox -r
+        - tox -e $(tox -l | grep django18 | tr '\n' ',')
+        - tox -e $(tox -l | grep django19 | tr '\n' ',')
+        - tox -e flake8
+        - tox -e isort-check


### PR DESCRIPTION
## Rationale

I've split CircleCI jobs into:
* `tox -e $(tox -l | grep django18 | tr '\n' ',')`
* `tox -e $(tox -l | grep django19 | tr '\n' ',')`
* `tox -e flake8`
* `tox -e isort-check`

This way, we can spot more quickly which jobs have failed, without reading the full log of the previous job.