### PR TITLE
Fix error on presets_lists endpoint

### DIFF
--- a/demo/tests/test_end_point.py
+++ b/demo/tests/test_end_point.py
@@ -14,7 +14,8 @@ from formidable.serializers.forms import FormidableSerializer
 from formidable.serializers.forms import ContextFormSerializer
 from formidable.serializers.fields import BASE_FIELDS, FieldSerializerRegister
 from formidable.serializers.presets import (
-    PresetsSerializer, PresetsArgsSerializer, PresetsArgSerializerWithItems,
+    PresetsClassSerializer, PresetsArgsSerializer,
+    PresetsArgSerializerWithItems,
 )
 from formidable.forms.validations.presets import (
     ConfirmationPresets, ComparisonPresets
@@ -1165,7 +1166,7 @@ class UpdateFormTestCase(TestCase):
         self.assertEquals(field.items.count(), 0)
 
 
-class TestPresetsSerializerRender(TestCase):
+class TestPresetsClassSerializerRender(TestCase):
 
     class PresetsTest(presets.Presets):
 
@@ -1193,8 +1194,7 @@ class TestPresetsSerializerRender(TestCase):
             )
 
     def test_render_preset_attr(self):
-        preset_instance = self.PresetsTest([])
-        serializer = PresetsSerializer(preset_instance)
+        serializer = PresetsClassSerializer(self.PresetsTest)
         self.assertTrue(serializer.data)
         data = serializer.data
         self.assertIn('label', data)
@@ -1205,16 +1205,6 @@ class TestPresetsSerializerRender(TestCase):
         self.assertEqual(data['description'], 'this is a test')
         self.assertIn('message', data)
         self.assertEqual(data['message'], 'thrown message when error test')
-
-    def test_render_class_attr(self):
-        preset_instance = self.PresetsTest([])
-        preset_instance.description = 'oh no !'
-        serializer = PresetsSerializer(preset_instance)
-        self.assertTrue(serializer.data)
-        data = serializer.data
-        self.assertIn('description', data)
-        self.assertNotEqual(data['description'], 'oh no !')
-        self.assertEqual(data['description'], 'this is a test')
 
     def test_render_preset_field_arg(self):
         field_arg = presets.PresetFieldArgument(
@@ -1286,11 +1276,7 @@ class TestPresetsSerializerRender(TestCase):
         self.assertIn('field', data['types'])
 
     def test_render_preset_with_argument(self):
-        preset_instance = self.PresetsTestWithArgs(arguments=[
-            PresetArg(slug='lhs', field_id='foo'),
-            PresetArg(slug='rhs', value='toto'),
-        ])
-        serializer = PresetsSerializer(preset_instance)
+        serializer = PresetsClassSerializer(self.PresetsTestWithArgs)
         self.assertTrue(serializer.data)
         data = serializer.data
         self.assertIn('arguments', data)

--- a/demo/tests/tests_integration.py
+++ b/demo/tests/tests_integration.py
@@ -241,6 +241,20 @@ class TestAccess(APITestCase):
                 self.assertEqual(access['preview_as'], 'FORM')
 
 
+class TestPresetsList(APITestCase):
+
+    def test_get(self):
+        response = self.client.get(reverse('formidable:presets_list'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.data) > 2)
+        for preset in response.data:
+            self.assertIn('slug', preset)
+            self.assertIn('label', preset)
+            self.assertIn('description', preset)
+            self.assertIn('message', preset)
+            self.assertIn('arguments', preset)
+
+
 class TestChain(APITestCase):
 
     def setUp(self):

--- a/formidable/serializers/presets.py
+++ b/formidable/serializers/presets.py
@@ -13,22 +13,6 @@ from rest_framework.serializers import (
 )
 
 
-class ClassAttrSerializer(object):
-
-    def get_attribute(self, instance):
-        return super(ClassAttrSerializer, self).get_attribute(
-            instance.__class__
-        )
-
-
-class CharFieldClassAttr(ClassAttrSerializer, fields.CharField):
-    pass
-
-
-class SlugFieldClassAttr(ClassAttrSerializer, fields.SlugField):
-    pass
-
-
 class PresetsArgsSerializerRegister(dict):
 
     lookup_field = 'has_items'
@@ -48,7 +32,7 @@ class PresetArgsListSerializer(ListSerializer):
         super(PresetArgsListSerializer, self).__init__(*args, **kwargs)
 
     def get_attribute(self, instance):
-        return instance.__class__._declared_arguments.values()
+        return instance._declared_arguments.values()
 
 
 class PresetsArgsSerializer(Serializer):
@@ -68,12 +52,12 @@ class PresetsArgSerializerWithItems(PresetsArgsSerializer):
     items = fields.DictField()
 
 
-class PresetsSerializer(Serializer):
+class PresetsClassSerializer(Serializer):
 
-    slug = SlugFieldClassAttr()
-    label = CharFieldClassAttr()
-    description = CharFieldClassAttr()
-    message = CharFieldClassAttr(source='default_message')
+    slug = fields.SlugField()
+    label = fields.CharField()
+    description = fields.CharField()
+    message = fields.CharField(source='default_message')
     arguments = PresetsArgsSerializer(many=True)
 
 

--- a/formidable/views.py
+++ b/formidable/views.py
@@ -15,7 +15,7 @@ from formidable.forms.validations.presets import presets_register
 from formidable.models import Formidable
 from formidable.serializers import FormidableSerializer, SimpleAccessSerializer
 from formidable.serializers.forms import ContextFormSerializer
-from formidable.serializers.presets import PresetsSerializer
+from formidable.serializers.presets import PresetsClassSerializer
 from rest_framework import exceptions
 from rest_framework.generics import (
     CreateAPIView, RetrieveAPIView, RetrieveUpdateAPIView
@@ -213,12 +213,9 @@ class PresetsList(six.with_metaclass(MetaClassView, APIView)):
     settings_permission_key = 'FORMIDABLE_PERMISSION_BUILDER'
 
     def get(self, request, format=None):
-        presets_declarations = [
-            klass([]) for klass in presets_register.values()
-        ]
-        serializer = PresetsSerializer(
+        serializer = PresetsClassSerializer(
             many=True,
-            instance=presets_declarations
+            instance=presets_register.values()
         )
         return Response(serializer.data)
 


### PR DESCRIPTION
In order to return a serialized Presets list, we tried to instantiate
presets with `arguments=[]`. But checks are done in `Presets.__init__`
on the arguments provided. This resulted in an `ImproperlyConfigured`
Exception.

The Serializer now takes the class as `instance` parameter instead of an
object.