### PR TITLE
Check for unicity in NestListSerializers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,9 @@ ChangeLog
 master (unreleased)
 ===================
 
-- Nothing here yet
+* Enforce unicity of keys in NestedListSerializers (#202)
+* Define __unicode__ and __str__ on models (#200)
+* Fix regression on presets_lists endpoint (#199)
 
 Release 0.8.1 (2017-03-07)
 ==========================

--- a/demo/tests/tests_integration.py
+++ b/demo/tests/tests_integration.py
@@ -86,6 +86,15 @@ class CreateFormTestCase(APITestCase):
                 field.accesses.filter(access_id=access, level=level).exists()
             )
 
+    def test_fields_slug(self):
+        data = deepcopy(form_data)
+        # duplicate field
+        data['fields'] *= 2
+        res = self.client.post(
+            reverse('formidable:form_create'), data, format='json'
+        )
+        self.assertEquals(res.status_code, 400)
+
     def test_with_items_in_fields(self):
         initial_count = Formidable.objects.count()
         res = self.client.post(
@@ -178,6 +187,17 @@ class UpdateFormTestCase(APITestCase):
         form = Formidable.objects.order_by('pk').last()
         self.assertEquals(form.pk, self.form.pk)
         self.assertEquals(form.fields.count(), 2)
+
+    def test_duplicate_items_update(self):
+        # create a form with items
+        data = deepcopy(form_data_items)
+        res = self.client.put(self.edit_url, data, format='json')
+        self.assertEquals(res.status_code, 200)
+        # update items with duplicate entries
+        data['fields'] *= 2
+        res = self.client.put(self.edit_url, data, format='json')
+        # expect validation error
+        self.assertEquals(res.status_code, 400)
 
     def test_delete_field_on_update(self):
         self.form.fields.create(

--- a/formidable/serializers/access.py
+++ b/formidable/serializers/access.py
@@ -36,6 +36,7 @@ class AccessListSerializer(NestedListSerializer):
     parent_name = 'field_id'
 
     def validate(self, data):
+        data = super(AccessListSerializer, self).validate(data)
         accesses_id = [accesses['access_id'] for accesses in data]
 
         for access in get_accesses():

--- a/formidable/serializers/fields.py
+++ b/formidable/serializers/fields.py
@@ -41,6 +41,8 @@ class FieldListSerializer(NestedListSerializer):
         order before the update/create method sorts the validated data
         by id.
         """
+        validated_data = super(FieldListSerializer, self).validate(
+                validated_data)
         for index, data in enumerate(validated_data):
             data['order'] = index
 


### PR DESCRIPTION
Fix unhandled exception in some cases and allows for better error reporting.