### PR TITLE
Remove the field size limit for the model field `formidable.models.Item.label`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ master (unreleased)
 ===================
 
 - Added a tox job to update/refresh the swagger-ui related static files (#210 / #213) - including documentation for developers.
+- Remove the field size limit for the model field `formidable.models.Item.label` (#225).
 
 Release 0.10.0 (2017-04-28)
 ===========================

--- a/demo/tests/test_models.py
+++ b/demo/tests/test_models.py
@@ -23,6 +23,20 @@ class FormTest(FormidableForm):
     )
 
 
+class FieldItemTestCase(TestCase):
+    def setUp(self):
+        super(FieldItemTestCase, self).setUp()
+        self.formidable = FormTest.to_formidable(label='label')
+
+    def test_field_size(self):
+        field = self.formidable.fields.get(slug='dropdown')
+        field.items.create(
+            value='hello',
+            label="hello" * 800,
+            order=42,
+        )
+
+
 class UnicodeTestCase(TestCase):
 
     def setUp(self):

--- a/formidable/migrations/0003_item_label_no_size_limit.py
+++ b/formidable/migrations/0003_item_label_no_size_limit.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('formidable', '0002_remove_access_display'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='item',
+            name='label',
+            field=models.TextField(),
+        ),
+    ]

--- a/formidable/models.py
+++ b/formidable/models.py
@@ -104,7 +104,7 @@ class Default(models.Model):
 class Item(models.Model):
     field = models.ForeignKey(Field, related_name='items')
     value = models.CharField(max_length=256)
-    label = models.CharField(max_length=256)
+    label = models.TextField()
     order = models.IntegerField()
     help_text = models.TextField(blank=True, null=True)
 


### PR DESCRIPTION
refs #225