### PR TITLE
Fix conditions save

### DIFF
--- a/demo/tests/test_conditions.py
+++ b/demo/tests/test_conditions.py
@@ -100,6 +100,7 @@ class ConditionTestCase(TestCase):
         form = form_class(data)
         self.assertTrue(form.is_valid())
         self.assertEqual(form.cleaned_data, {'checkbox': True})
+        self.assertTrue('bar' not in form.fields)
 
     def test_padawan_displayed(self):
         form_class = self.get_form_class(self.formidable, 'padawan')
@@ -123,6 +124,7 @@ class ConditionTestCase(TestCase):
         form = form_class(data)
         self.assertTrue(form.is_valid())
         self.assertEqual(form.cleaned_data, {'checkbox': True})
+        self.assertTrue('bar' not in form.fields)
 
     def test_save_update(self):
         self.formidable.save()

--- a/demo/tests/test_end_point.py
+++ b/demo/tests/test_end_point.py
@@ -889,6 +889,38 @@ class CreateSerializerTestCase(TestCase):
         serializer = FormidableSerializer(data=data)
         self.assertTrue(serializer.is_valid(), serializer.errors)
         form = serializer.save()
+        form = Formidable.objects.get(pk=form.pk)
+        self.assertEqual(len(form.conditions), 1)
+        condition = form.conditions[0]
+        self.assertIn('name', condition)
+        self.assertEqual(condition['name'], 'my condition')
+        self.assertIn('action', condition)
+        self.assertEqual(condition['action'], 'display_iff')
+        self.assertIn('fields_ids', condition)
+        self.assertEqual(condition['fields_ids'], ['input-date'])
+        self.assertIn('tests', condition)
+        self.assertEqual(len(condition['tests']), 1)
+        test = condition['tests'][0]
+        self.assertIn('operator', test)
+        self.assertEqual(test['operator'], 'eq')
+        self.assertIn('field_id', test)
+        self.assertEqual(test['field_id'], 'text_input')
+        self.assertIn('values', test)
+        self.assertEqual(test['values'], ['text'])
+
+    def test_conditions_on_update(self):
+        data = copy.deepcopy(self.data)
+        data['fields'] = copy.deepcopy(self.fields_with_validation)
+        serializer = FormidableSerializer(data=data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        form = serializer.save()
+        # update with conditions
+        data['conditions'] = copy.deepcopy(self.valid_conditions)
+        serializer = FormidableSerializer(instance=form, data=data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        form = serializer.save()
+        # reload form from the database
+        form = Formidable.objects.get(pk=form.pk)
         self.assertEqual(len(form.conditions), 1)
         condition = form.conditions[0]
         self.assertIn('name', condition)

--- a/demo/tests/test_end_point.py
+++ b/demo/tests/test_end_point.py
@@ -889,7 +889,7 @@ class CreateSerializerTestCase(TestCase):
         serializer = FormidableSerializer(data=data)
         self.assertTrue(serializer.is_valid(), serializer.errors)
         form = serializer.save()
-        form = Formidable.objects.get(pk=form.pk)
+        form.refresh_from_db()
         self.assertEqual(len(form.conditions), 1)
         condition = form.conditions[0]
         self.assertIn('name', condition)
@@ -919,8 +919,8 @@ class CreateSerializerTestCase(TestCase):
         serializer = FormidableSerializer(instance=form, data=data)
         self.assertTrue(serializer.is_valid(), serializer.errors)
         form = serializer.save()
-        # reload form from the database
-        form = Formidable.objects.get(pk=form.pk)
+        # reload form from the database, ensure conditions were saved
+        form.refresh_from_db()
         self.assertEqual(len(form.conditions), 1)
         condition = form.conditions[0]
         self.assertIn('name', condition)

--- a/formidable/forms/conditions.py
+++ b/formidable/forms/conditions.py
@@ -141,4 +141,5 @@ class DisplayIffCondition(Condition):
             for field_id in self.fields_ids:
                 cleaned_data.pop(field_id, None)
                 form.errors.pop(field_id, None)
+                del form.fields[field_id]
         return cleaned_data

--- a/formidable/migrations/0005_conditions_default.py
+++ b/formidable/migrations/0005_conditions_default.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+import jsonfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('formidable', '0004_formidable_conditions'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='formidable',
+            name='conditions',
+            field=jsonfield.fields.JSONField(default=list),
+        ),
+    ]

--- a/formidable/serializers/forms.py
+++ b/formidable/serializers/forms.py
@@ -77,15 +77,16 @@ class FormidableSerializer(WithNestedSerializer):
     def create(self, validated_data):
         conditions = validated_data.pop('conditions', None)
         instance = super(FormidableSerializer, self).create(validated_data)
-        instance.conditions = conditions
+        if conditions:
+            instance.conditions = conditions
+            instance.save()
         return instance
 
     def update(self, instance, validated_data):
-        conditions = validated_data.pop('conditions', None)
+        instance.conditions = validated_data.pop('conditions', None)
         instance = super(FormidableSerializer, self).update(
             instance, validated_data
         )
-        instance.conditions = conditions
         return instance
 
     def _get_fields_slugs(self, data):


### PR DESCRIPTION
Fix 3 issues with conditions introduced in previous commits but not yet released. 
- missing django db migration for default value on `conditions`
- remove fields from the generated django form if they are hidden by the conditional fields
- save() was not done properly on create/update.
  Note on the last point : if we create a form with conditions, there will be one extra SQL request to update the form and add the conditions (easier way to handle nested JSONField with DRF)

## Review

* [ ] Tests<!-- mandatory -->
* [ ] Migration(s)
* [ ] Delete your branch