### PR TITLE
Add a ValidateView that works with ContextForm JSON

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ ChangeLog
 master (unreleased)
 ===================
 
-- Nothing yet.
+- Add a ValidateView that works with ContextForm JSON (#246).
 
 Release 0.13.1 (2017-07-17)
 ===========================

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
     override:
-        - pip install --upgrade tox
+        - pip install --upgrade tox virtualenv
 
 test:
     override:

--- a/demo/demo/urls.py
+++ b/demo/demo/urls.py
@@ -1,10 +1,13 @@
 from django.conf.urls import include, url
 from django.contrib import admin
 
-from demo.views import FormPreview
+from demo.views import FormPreview, DemoValidateViewFromSchema
 
 urlpatterns = [
     url(r'^api/', include('formidable.urls', namespace='formidable')),
+    url(r'^api/forms/(?P<pk>\d+)/validate_schema/?$',
+        DemoValidateViewFromSchema.as_view(),
+        name='form_validation_schema'),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^preview/(?P<pk>\d+)/', FormPreview.as_view()),
     url(r'^forms/', include('demo.builder.urls', namespace='builder')),

--- a/demo/demo/views.py
+++ b/demo/demo/views.py
@@ -3,6 +3,7 @@
 from django.views.generic.edit import FormView
 
 from formidable.models import Formidable
+import formidable.views
 from formidable.views import ContextFormDetail
 
 
@@ -24,3 +25,12 @@ class DemoContextFormDetail(ContextFormDetail):
 
     def get_context(self, request, **kwargs):
         return kwargs['role']
+
+
+class DemoValidateViewFromSchema(formidable.views.ValidateViewFromSchema):
+
+    settings_permission_key = 'FORMIDABLE_PERMISSION_USING'
+
+    def get_formidable_object(self, kwargs):
+        formidable = Formidable.objects.get(pk=kwargs['pk'])
+        return formidable.to_json()

--- a/demo/tests/perfs/test_integration.perf.yml
+++ b/demo/tests/perfs/test_integration.perf.yml
@@ -1,0 +1,19 @@
+TestContextFormEndPoint.test_queryset:
+- db: 'SELECT ... FROM "django_session" WHERE ("django_session"."expire_date" > # AND "django_session"."session_key" = #)'
+- db: 'SELECT ... FROM "formidable_formidable" WHERE "formidable_formidable"."id" = #'
+- db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = # ORDER BY "formidable_field"."order" ASC'
+- db: 'SELECT ... FROM "formidable_access" WHERE ("formidable_access"."access_id" = # AND NOT ("formidable_access"."level" = #) AND "formidable_access"."field_id" IN (...))'
+- db: SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...) ORDER BY "formidable_item"."order" ASC
+- db: SELECT ... FROM "formidable_validation" WHERE "formidable_validation"."field_id" IN (...)
+- db: SELECT ... FROM "formidable_default" WHERE "formidable_default"."field_id" IN (...)
+- db: 'SELECT ... FROM "formidable_preset" WHERE "formidable_preset"."form_id" = #'
+- db: SELECT ... FROM "formidable_presetarg" WHERE "formidable_presetarg"."preset_id" IN (...)
+UpdateFormTestCase.test_queryset_on_get:
+- db: 'SELECT ... FROM "formidable_formidable" WHERE "formidable_formidable"."id" = #'
+- db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = # ORDER BY "formidable_field"."order" ASC'
+- db: SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...) ORDER BY "formidable_item"."order" ASC
+- db: SELECT ... FROM "formidable_default" WHERE "formidable_default"."field_id" IN (...)
+- db: SELECT ... FROM "formidable_validation" WHERE "formidable_validation"."field_id" IN (...)
+- db: SELECT ... FROM "formidable_access" WHERE "formidable_access"."field_id" IN (...)
+- db: 'SELECT ... FROM "formidable_preset" WHERE "formidable_preset"."form_id" = #'
+- db: SELECT ... FROM "formidable_presetarg" WHERE "formidable_presetarg"."preset_id" IN (...)

--- a/demo/tests/test_integration.py
+++ b/demo/tests/test_integration.py
@@ -445,6 +445,8 @@ class MyFormPresets(MyForm):
 
 class TestValidationEndPoint(FormidableAPITestCase):
 
+    url = 'formidable:form_validation'
+
     def setUp(self):
         super(TestValidationEndPoint, self).setUp()
         self.formidable = MyForm.to_formidable(label='title')
@@ -459,7 +461,7 @@ class TestValidationEndPoint(FormidableAPITestCase):
         session['role'] = 'padawan'
         session.save()
         res = self.client.get(
-            reverse('formidable:form_validation', args=[self.formidable.pk]),
+            reverse(self.url, args=[self.formidable.pk]),
             parameters, format='json'
         )
         self.assertEqual(res.status_code, 204)
@@ -473,7 +475,7 @@ class TestValidationEndPoint(FormidableAPITestCase):
         session['role'] = 'padawan'
         session.save()
         res = self.client.get(
-            reverse('formidable:form_validation', args=[self.formidable_p.pk]),
+            reverse(self.url, args=[self.formidable_p.pk]),
             parameters, format='json'
         )
         self.assertEqual(res.status_code, 204)
@@ -487,7 +489,7 @@ class TestValidationEndPoint(FormidableAPITestCase):
         session['role'] = 'padawan'
         session.save()
         res = self.client.get(
-            reverse('formidable:form_validation', args=[self.formidable_p.pk]),
+            reverse(self.url, args=[self.formidable_p.pk]),
             parameters, format='json'
         )
         self.assertEqual(res.status_code, 400)
@@ -504,7 +506,7 @@ class TestValidationEndPoint(FormidableAPITestCase):
         session['role'] = 'padawan'
         session.save()
         res = self.client.get(
-            reverse('formidable:form_validation', args=[self.formidable.pk]),
+            reverse(self.url, args=[self.formidable.pk]),
             parameters, format='json'
         )
         self.assertEqual(res.status_code, 400)
@@ -523,7 +525,12 @@ class TestValidationEndPoint(FormidableAPITestCase):
         session['role'] = 'padawan'
         session.save()
         res = self.client.get(
-            reverse('formidable:form_validation', args=[formidable.pk]),
+            reverse(self.url, args=[formidable.pk]),
             parameters, format='json'
         )
         self.assertEqual(res.status_code, 204)
+
+
+class TestValidationFromSchemaEndPoint(TestValidationEndPoint):
+
+    url = 'form_validation_schema'

--- a/demo/tests/test_permissions.py
+++ b/demo/tests/test_permissions.py
@@ -42,6 +42,7 @@ class TestMetaClassPermissions(TestCase):
         self.assertEqual(len(permission_classes), 1)
         self.assertEqual(permission_classes[0], AllowAny)
 
+    @override_settings()
     def test_no_settings_key_define(self):
         del settings.FORMIDABLE_DEFAULT_PERMISSION
 

--- a/formidable/forms/__init__.py
+++ b/formidable/forms/__init__.py
@@ -70,7 +70,12 @@ def get_dynamic_form_class_from_schema(schema, field_factory=None):
     field_factory = field_factory or field_builder_from_schema.FormFieldFactory()  # noqa
     doc = schema['description']
     for field in schema['fields']:
-        attrs[field['slug']] = field_factory.produce(field)
+        try:
+            form_field = field_factory.produce(field)
+        except field_builder.SkipField:
+            pass
+        else:
+            attrs[field['slug']] = form_field
 
     conditions = schema.get('conditions', None) or []
     attrs['_conditions'] = conditions_register.build(


### PR DESCRIPTION
ValidateView needs a Formidable object.

We had issues in test because, when we need to delete a setting, tests
require to be decorated with `@override_settings()` without any
argument.

> You can also simulate the absence of a setting by deleting it after
> settings have been overridden, like this:
> ```python
> @override_settings()
> def test_something(self):
>     del settings.LOGIN_URL
>     ...
> ```
> — django.test.modify_settings [1]

For CircleCI, we needed to upgrade `virtualenv` package as well as `tox`
because tests were failing with an old version of the package.

References:
[1] https://docs.djangoproject.com/en/1.8/topics/testing/tools/#django.test.modify_settings

## Review

* [x] Tests<!-- mandatory -->
* [x] Docs/comments
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch
