### PR TITLE
Added a new "serve-docs" target to the makefile

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ ChangeLog
 master (unreleased)
 ===================
 
-- Nothing yet.
+- [Doc] New Makefile target to serve the documentation.
 
 Release 0.14.0 (2017-08-23)
 ===========================

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,16 @@ test:
 docs:
 	tox -e docs
 
+PYTHON3 := $(shell command -v python3 2> /dev/null)
+# target: serve-docs - use a tiny HTTP static server for browsing the doc
+.PHONY: serve-docs
+serve-docs:
+ifdef PYTHON3
+	cd docs/build/html; python3 -m http.server
+else
+	cd docs/build/html; python -m SimpleHTTPServer
+endif
+
 ##################### Crowdin-related commands
 
 # target: crowdin-venv - create the crowdin-ready virtualenv

--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,12 @@ If you want to build the documentation locally, you can try to run one of the fo
 
     A recent version of `tox` must be available on your system.
 
+You can also browse the documentation locally, using the following, for example:
+
+.. code:: sh
+
+    $ make docs serve-docs
+
 Quick-Start
 ===========
 


### PR DESCRIPTION
this will fire up a small Python HTTP server to browse the documentation 
locally.