### PR TITLE
Deprecation warnings for Presets and DRF 3.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ master (unreleased)
 
 - [Doc] New Makefile target to serve the documentation.
 
+.. warning::
+
+    This version is the last one to support Form Presets (form validation rules). The whole software logic and data will be wiped off on the next release. If needed, make backups and try to convert your existing presets to field validation rules. refs #249.
+
+.. warning::
+
+    This version is the last one to support Django Rest Framework 3.3. Please upgrade to the latest available to date (3.6.2). refs #239.
+
 Release 0.14.0 (2017-08-23)
 ===========================
 

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,11 @@ else
 	cd docs/build/html; python -m SimpleHTTPServer
 endif
 
+# target: swagger-statics - rebuild the swagger statics needed to display the swagger specs
+.PHONY: swagger-statics
+swagger-statics:
+	tox -e swagger-statics
+
 ##################### Crowdin-related commands
 
 # target: crowdin-venv - create the crowdin-ready virtualenv

--- a/docs/source/_static/specs/formidable.js
+++ b/docs/source/_static/specs/formidable.js
@@ -571,7 +571,7 @@ var spec = {
         },
         "/builder/presets/": {
             "get": {
-                "description": "Presets description.\n",
+                "description": "Presets description.\n  **DEPRECATION WARNING:** will be deprecated as of 1.0.0.\n",
                 "responses": {
                     "200": {
                         "description": "A list of presets",

--- a/docs/source/deprecations.rst
+++ b/docs/source/deprecations.rst
@@ -1,0 +1,22 @@
+====================
+Deprecation timeline
+====================
+
+From 0.15 to 1.0.0
+==================
+
+(Late August / Early September 2017)
+
+Form Presets
+------------
+
+.. deprecated:: 1.0.0
+
+    Form presets will be deprecated in favor of Field validation rules. If needed, you'll have to convert your existing Presets to Field validations, because Presets data will be destroyed using a table deletion.
+
+Django Rest Framework version
+-----------------------------
+
+.. deprecated:: 1.0.0
+
+    DRF 3.3 support will be deprecated. We recommend to use the latest to date (3.6.4).

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,7 +13,7 @@ Contents:
    callbacks
    dev
    translations
-
+   deprecations
 
 Indices and tables
 ==================

--- a/docs/swagger/formidable.yml
+++ b/docs/swagger/formidable.yml
@@ -67,6 +67,7 @@ paths:
       summary: Get available presets
       description: |
         Presets description.
+          **DEPRECATION WARNING:** will be deprecated as of 1.0.0.
       responses:
         200:
           description: A list of presets

--- a/formidable/__init__.py
+++ b/formidable/__init__.py
@@ -1,3 +1,21 @@
-default_app_config = 'formidable.app.FormidableConfig'
+import warnings
 
+
+default_app_config = 'formidable.app.FormidableConfig'
 version = '0.15.0.dev0'
+
+# TO BE REMOVED ON 1.0.0
+with warnings.catch_warnings():
+    warnings.simplefilter('always', DeprecationWarning)
+    page = 'https://django-formidable.readthedocs.io/en/latest/deprecations.html'  # noqa
+    warnings.warn(
+        'Form Presets are about to be deprecated. '
+        'Please refer to the Deprecation Timeline document for more details '
+        '{}.'.format(page),
+        DeprecationWarning)
+    warnings.warn(
+        'Support for Django Rest Framework v3.3 is about to be deprecated. '
+        'Please refer to the Deprecation Timeline document for more details '
+        '{}.'.format(page),
+        DeprecationWarning
+    )


### PR DESCRIPTION
## Content

- Warnings in the Sphinx documentation (deprecations timeline page)
- Added a Deprecation warning about Presets in the swagger specs.
- ``DeprecationWarning`` warnings at runtime,
- Changelog updated
- (unrelated: added a Makefile target to build swagger statics independently)

## Review

This PR will close #239 and will close #249

* [x] Docs/comments
  * [x] *IN CASE YOU'VE CHANGED THE `formidable.yml` file*: run ``tox -e swagger-statics`` to rebuild the swagger static files **and** commit the diff.
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch
