### PR TITLE
Drop preset fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ master (unreleased)
   - Removed from model serializers, and test code.
   - Translation strings have been removed.
   - Swagger documentation updated to reflect this API change.
+  - Removed fields that reference preset models in forms and preset args tables (#259).
 
 .. warning::
 

--- a/formidable/migrations/0006_drop_preset_fields.py
+++ b/formidable/migrations/0006_drop_preset_fields.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('formidable', '0005_conditions_default'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='preset',
+            name='form',
+        ),
+        migrations.RemoveField(
+            model_name='presetarg',
+            name='preset',
+        ),
+    ]


### PR DESCRIPTION
Don't drop tables, drop only fields.
The tables will be dropped in a further Django migration, and the appropriate release (post 1.0.0)

## Review

refs #255

* [x] Tests<!-- mandatory -->
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch
