### PR TITLE
Reflect incompatibility between Django 1.8 and DRF 3.7 by changing requirements in tox tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ ChangeLog
 master (unreleased)
 ===================
 
-Nothing here yet.
+- As of its 3.7 version, it appears that Django REST Framework is no longer compatible with Django 1.8. Added a mention in the README, in the deprecation timeline, and changed tox requirements to reflect this (#272).
 
 Release 1.0.1 (2017-10-04)
 ==========================

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,10 @@ Warnings
 
 See the `Deprecation timeline <http://django-formidable.readthedocs.io/en/latest/deprecations.html>`_ document for more information on deprecated versions.
 
+.. warning::
+
+   As of its 3.7 version, it appears that Django REST Framework only supports Django 1.10 & 1.11. Carefully freeze your dependencies if your Django version is not compatible.
+
 License
 =======
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ changedir = demo
 deps =
     ; Django versions
     django18: Django>=1.8,<1.9
+    django18: djangorestframework<3.7
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     ; Requirements from demo project


### PR DESCRIPTION

## Review

This PR closes #272

* [x] Tests<!-- mandatory -->
* [x] Docs/comments
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch
